### PR TITLE
Env Hierarchy

### DIFF
--- a/apps/electron/src/main/env.ts
+++ b/apps/electron/src/main/env.ts
@@ -51,7 +51,7 @@ async function findEnvFilesRecursively(dir: string) {
       // Recursively search in subdirectory
       const subDirEnvFiles = await findEnvFilesRecursively(fullPath);
       envFiles = envFiles.concat(subDirEnvFiles);
-    } else if (entry.isFile() && (entry.name.startsWith(".env") || entry.name.endsWith(".env"))) {
+    } else if (entry.isFile() && entry.name.startsWith(".env")) {
       envFiles.push(fullPath);
     }
   }


### PR DESCRIPTION
https://github.com/VoidenHQ/voiden/issues/128

Given a project with these env files:
```
.env
.env.foo
.env.foo.bar
```
Choosing `.env.foo` would include `.env` as its base, and choosing `.env.foo.bar` would include `.env` and `.env.foo` as its base.