### PR TITLE
Bake cookies into the assertionEngine and runtimeVariables system

### DIFF
--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,3 +1,5 @@
+import { parseCookies } from '@voiden/core-extensions/shared/utils/cookieParser';
+
 interface RuntimeVariable {
     key: string;
     value: string;
@@ -127,6 +129,17 @@ function getValueByPath(obj: any, path: string): any {
         }
         // Check if current is an array of key-value pairs
         if (Array.isArray(current) && current.length > 0) {
+            if ('key' in current[0] && 'value' in current[0] && key.toLowerCase() === 'set-cookie') {
+                const cookies = parseCookies(current);
+
+                if (i === keys.length - 1) {
+                    return cookies;
+                }
+
+                current = cookies;
+                continue;
+            }
+
             let value = ""
             if( 'key' in current[0] && 'value' in current[0]){
                 value = findInKeyValueInKeyValue(current);

--- a/core-extensions/package.json
+++ b/core-extensions/package.json
@@ -35,6 +35,11 @@
       "types": "./dist/simple-assertions/help/index.d.ts",
       "import": "./dist/simple-assertions/help/index.js",
       "default": "./dist/simple-assertions/help/index.js"
+    },
+    "./shared/utils/cookieParser": {
+      "types": "./dist/shared/utils/cookieParser.d.ts",
+      "import": "./dist/shared/utils/cookieParser.js",
+      "default": "./dist/shared/utils/cookieParser.js"
     }
   },
   "scripts": {

--- a/core-extensions/src/shared/utils/cookieParser.ts
+++ b/core-extensions/src/shared/utils/cookieParser.ts
@@ -1,0 +1,86 @@
+interface CookieAttributes {
+    value: string;
+
+    [key: string]: string | boolean;
+}
+
+interface ParsedCookie {
+    name: string;
+    attributes: CookieAttributes;
+}
+
+/**
+ * Parses a single cookie attribute (e.g., "Path=/api" or "Secure")
+ */
+function parseAttribute(attributeString: string): [string, string | boolean] {
+    const equalIndex = attributeString.indexOf('=');
+
+    if (equalIndex === -1) {
+        // Boolean attribute (e.g., Secure, HttpOnly)
+        return [attributeString, true];
+    }
+
+    // Key-value attribute (e.g., Path=/api, Max-Age=3600)
+    const name = attributeString.substring(0, equalIndex).trim();
+    const value = attributeString.substring(equalIndex + 1).trim();
+    return [name, value];
+}
+
+/**
+ * Parses a single Set-Cookie header value into name and attributes
+ */
+function parseSingleCookie(cookieString: string): ParsedCookie | null {
+    const parts = cookieString.split(';').map(part => part.trim());
+
+    if (parts.length === 0) {
+        return null;
+    }
+
+    const firstEqualsIndex = parts[0].indexOf('=');
+    const cookieName = parts[0].substring(0, firstEqualsIndex).trim();
+    const cookieValue = parts[0].substring(firstEqualsIndex + 1).trim();
+
+    if (!cookieName) {
+        return null;
+    }
+
+    // Parse all attributes
+    const attributes: CookieAttributes = {value: cookieValue};
+
+    for (let i = 1; i < parts.length; i++) {
+        const [attrName, attrValue] = parseAttribute(parts[i]);
+        attributes[attrName] = attrValue;
+    }
+
+    return {name: cookieName, attributes};
+}
+
+/**
+ * Parses Set-Cookie header(s) into a structured object
+ * @param headers - Array of {key, value} header objects
+ * @returns Object with cookie names as keys and cookie details as values
+ *
+ * If multiple Set-Cookie headers have the same cookie name, the last one wins
+ * (matching browser behavior).
+ *
+ * @example
+ * const headers = [
+ *   { key: 'set-cookie', value: 'session=abc123; Path=/; Secure' }
+ * ];
+ * const cookies = parseCookies(headers);
+ * // Returns: { session: { value: 'abc123', Path: '/', Secure: true } }
+ */
+export function parseCookies(headers: Array<{ key: string, value: string }>): Record<string, CookieAttributes> {
+    if (!headers || !Array.isArray(headers)) {
+        return {};
+    }
+
+    const cookies: Record<string, CookieAttributes> = {};
+
+    headers.filter(header => header.key.toLowerCase() === 'set-cookie')
+        .map(header => parseSingleCookie(header.value))
+        .filter(cookie => cookie !== null)
+        .forEach(cookie => cookies[cookie.name] = cookie.attributes);
+
+    return cookies;
+}

--- a/core-extensions/src/simple-assertions/lib/assertionEngine.ts
+++ b/core-extensions/src/simple-assertions/lib/assertionEngine.ts
@@ -3,6 +3,8 @@
  * Executes assertions against HTTP responses
  */
 
+import { parseCookies } from '../../shared/utils/cookieParser';
+
 export interface Assertion {
   description: string;
   field: string;
@@ -52,7 +54,20 @@ export function extractFieldValue(field: string, context: AssertionContext): any
 
   // Handle header access: header.Content-Type or headers.Content-Type
   if (normalizedField.startsWith('header.') || normalizedField.startsWith('headers.')) {
-    const headerName = normalizedField.split('.')[1];
+    const parts = normalizedField.split('.');
+    const headerName = parts[1];
+
+    if (headerName.toLowerCase() === 'set-cookie') {
+      const cookies = parseCookies(context.response.headers);
+
+      if (parts.length === 2) {
+        return cookies;
+      }
+
+      const remainingPath = parts.slice(2).join('.');
+      return extractFromObject(cookies, remainingPath);
+    }
+
     const header = context.response.headers.find(
       (h) => h.key.toLowerCase() === headerName.toLowerCase()
     );


### PR DESCRIPTION
I'd like to be able to handle cookies. I've created a util class for parsing cookies from headers, and implemented it in the assertionEngine and runtimeVariables. Here are some screenshots showing it working in an Assertion Block
<img width="1039" height="562" alt="image" src="https://github.com/user-attachments/assets/3ff45331-69f3-4ff1-a6e2-9f8749da77d1" />
<img width="1058" height="249" alt="image" src="https://github.com/user-attachments/assets/fe3fb000-2462-46a4-bb22-593e3ebfc5d3" />
