### PR TITLE
use-more-robust-yaml-serializer (#147)

### DIFF
--- a/core-extensions/src/voiden-rest-api/lib/helpers.ts
+++ b/core-extensions/src/voiden-rest-api/lib/helpers.ts
@@ -214,7 +214,9 @@ export function convertBlocksToVoidFile(title: string, blocks: JSONContent[]): s
       voidContent += '```void\n';
       voidContent += '---\n';
       voidContent += YAML.stringify(blockWithUID, {
-        lineWidth: 0,
+        lineWidth: 0, // Don't wrap lines
+        defaultStringType: 'QUOTE_DOUBLE',
+        defaultKeyType: 'PLAIN',
       });
       voidContent += '---\n';
       voidContent += '```\n\n';


### PR DESCRIPTION
The `jsonToYaml` function has bugs in it. I tried replacing it with YAML.stringify and everything works as expected. I noticed that other places in the project already use YAML.stringify instead of doing it manually.