### PR TITLE
import openapi spec should use relative path when possible (#131)

### DIFF
--- a/core-extensions/src/openapi-import/components/OpenAPIImportPanel.tsx
+++ b/core-extensions/src/openapi-import/components/OpenAPIImportPanel.tsx
@@ -316,10 +316,21 @@ export const OpenAPIImportPanel: React.FC<Props> = ({ context }) => {
     else refreshFromEditor();
     const fetchActiveTab = async ()=>{
       try {
-      const tab = await context.tab?.getActiveTab() as DocumentTab;
-        setActiveSource(tab.source);
-    } catch {
-    }
+        const tab = await context.tab?.getActiveTab() as DocumentTab;
+        const project = await context.project?.getActiveProject();
+
+        let relativePath = tab.source;
+        if (project && tab.source.startsWith(project)) {
+          relativePath = tab.source.slice(project.length);
+          if (relativePath.startsWith('/')) {
+            relativePath = relativePath.slice(1);
+          }
+        }
+
+        setActiveSource(relativePath);
+      } catch {
+
+      }
     }
     fetchActiveTab();
   }, []);

--- a/core-extensions/src/openapi-import/nodes/OpenApiSpecLink.tsx
+++ b/core-extensions/src/openapi-import/nodes/OpenApiSpecLink.tsx
@@ -66,10 +66,11 @@ export const createOpenApiSpecLink = (context: ExtendedPluginContextExplicit) =>
                 // Resolve full path
                 let fullPath = filePath;
                 if (!isExternal && activeProject && !filePath.startsWith(activeProject)) {
-                    fullPath = `${activeProject}${filePath}`;
+                    const separator = filePath.startsWith('/') ? '' : '/';
+                    fullPath = `${activeProject}${separator}${filePath}`;
                 }
 
-                await context.project.openFile(filePath, true);
+                await context.project.openFile(fullPath, true);
 
             } catch (error) {
                 console.error("Failed to open file:", error);


### PR DESCRIPTION
#131 