### PR TITLE
fix: auto-close terminal tab on process exit

### DIFF
--- a/apps/ui/src/core/layout/components/PanelContent.tsx
+++ b/apps/ui/src/core/layout/components/PanelContent.tsx
@@ -498,7 +498,7 @@ const PanelContentInner = ({ panelId }: { panelId: string }) => {
       tabId: tab.id,
       cwd: tab.source,
     }));
-    return <TerminalManager terminalTabs={terminals} activeTabId={tabContent.tabId} />;
+    return <TerminalManager terminalTabs={terminals} activeTabId={tabContent.tabId} panelId={panelId} />;
   }
 
   if (tabContent.type === "settings") {

--- a/apps/ui/src/core/terminal/components/Terminal.tsx
+++ b/apps/ui/src/core/terminal/components/Terminal.tsx
@@ -5,17 +5,20 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 import { useSettings } from "../../settings/hooks/useSettings";
 import { useNerdFont } from "../hooks/useNerdFont";
+import { useClosePanelTab } from "@/core/layout/hooks/usePanelTabs";
 
 interface TerminalProps {
   tabId: string;
   cwd: string;
+  panelId: string;
 }
 
 const getCssVar = (name: string) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 
-export const Terminal = ({ tabId, cwd }: TerminalProps) => {
+export const Terminal = ({ tabId, cwd, panelId }: TerminalProps) => {
   const { settings } = useSettings();
   const { fontFamily } = useNerdFont();
+  const { mutate: closeTab } = useClosePanelTab();
   const terminalRef = useRef<HTMLDivElement>(null);
   const fitAddonRef = useRef<FitAddon>();
   const xtermRef = useRef<XTerm | null>(null);
@@ -333,8 +336,12 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
       // Subscribe to exit events
       const unsubscribeExit = window.electron?.terminal.onExit(id, ({ exitCode, signal }: any) => {
         setExitInfo({ code: exitCode, signal });
-        xterm.writeln(`\r\n\r\n[Process exited with code ${exitCode}]`);
-        xterm.blur(); // visually show that the terminal is not active
+        if (exitCode === 0) {
+          closeTab({ panelId, tabId });
+        } else {
+          xterm.writeln(`\r\n\r\n[Process exited with code ${exitCode}]`);
+          xterm.blur();
+        }
       });
       if (unsubscribeExit) {
         cleanupFunctionsRef.current.push(unsubscribeExit);

--- a/apps/ui/src/core/terminal/components/TerminalManager.tsx
+++ b/apps/ui/src/core/terminal/components/TerminalManager.tsx
@@ -9,9 +9,10 @@ interface TerminalData {
 interface TerminalManagerProps {
   terminalTabs: TerminalData[];
   activeTabId: string;
+  panelId: string;
 }
 
-export const TerminalManager = ({ terminalTabs, activeTabId }: TerminalManagerProps) => {
+export const TerminalManager = ({ terminalTabs, activeTabId, panelId }: TerminalManagerProps) => {
   return (
     <div className="h-full w-full pb-8 ">
       <div
@@ -34,7 +35,7 @@ export const TerminalManager = ({ terminalTabs, activeTabId }: TerminalManagerPr
               pointerEvents: tab.tabId === activeTabId ? "auto" : "none",
             }}
           >
-            <Terminal tabId={tab.tabId} cwd={tab.cwd} />
+            <Terminal tabId={tab.tabId} cwd={tab.cwd} panelId={panelId} />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Terminal tab now automatically closes when the shell process exits with code 0
- Non-zero exit codes still display the exit message so users can inspect errors
- Threads `panelId` through `TerminalManager` → `Terminal` to enable tab closure from within the terminal component

Fixes #200

## Test plan
- [ ] Open a terminal tab, type `exit` — tab should auto-close
- [ ] Open a terminal tab, run a command that fails (non-zero exit) — should still show exit message
- [ ] Open multiple terminal tabs, exit one — only that tab closes
- [ ] Verify no regression on terminal creation and normal usage

🤖 PR description generated with Claude