### PR TITLE
refactor: centralize keyboard shortcuts

### DIFF
--- a/apps/electron/src/preload/api/index.ts
+++ b/apps/electron/src/preload/api/index.ts
@@ -61,4 +61,5 @@ export const electronApi = {
   mainwindow: mainWindow,
   logger: loggerAPI,
   processMonitor: processMonitorAPI,
+  platform: process.platform,
 };

--- a/apps/ui/src/core/components/ui/sidebar.tsx
+++ b/apps/ui/src/core/components/ui/sidebar.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/core/components/ui/separator.tsx";
 import { Sheet, SheetContent } from "@/core/components/ui/sheet.tsx";
 import { Skeleton } from "@/core/components/ui/skeleton.tsx";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/core/components/ui/tooltip.tsx";
+import { matchesShortcut } from "@/core/shortcuts";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -82,17 +83,7 @@ const SidebarProvider = React.forwardRef<
       }
 
       // Check for Cmd+B (Mac) or Ctrl+B (Windows/Linux)
-      const isMac = navigator.platform ? navigator.platform.toLowerCase().includes('mac') : false;
-      const modifierPressed = isMac ? event.metaKey : event.ctrlKey;
-
-      // Ensure it's exactly Cmd/Ctrl + B (no other modifiers like Shift or Alt)
-      const hasOtherModifiers =
-        (isMac && event.ctrlKey) || // Ctrl on Mac
-        (!isMac && event.metaKey) || // Cmd on Windows/Linux
-        event.altKey ||
-        event.shiftKey;
-
-      if (modifierPressed && !hasOtherModifiers && event.key.toLowerCase() === 'b') {
+      if (matchesShortcut("ToggleSidebar", event)) {
         event.preventDefault();
         event.stopPropagation();
         toggleSidebar();

--- a/apps/ui/src/core/editors/voiden/VoidenEditor.tsx
+++ b/apps/ui/src/core/editors/voiden/VoidenEditor.tsx
@@ -133,6 +133,7 @@ import { usePanelStore } from "@/core/stores/panelStore";
 import { useGetActiveDocument } from "@/core/documents/hooks";
 import { useVoidVariables } from "@/core/runtimeVariables/hook/useVariableCapture";
 import { useQueryClient } from "@tanstack/react-query";
+import { matchesShortcut } from "@/core/shortcuts";
 
 interface VoidenEditorStore {
   editor: Editor | null;
@@ -439,11 +440,8 @@ const VoidenEditorInner = ({
         return;
       }
 
-      const key = e.key.toLowerCase();
-      const mod = isMac ? e.metaKey : e.ctrlKey;
-
       // Cmd/Ctrl+F: Open find (without replace)
-      if (mod && key === "f" && hasSearch && !e.shiftKey) {
+      if (matchesShortcut("Find", e) && hasSearch) {
         e.preventDefault();
         setShowFind(true);
         setShowReplaceSection(false);
@@ -452,7 +450,7 @@ const VoidenEditorInner = ({
       }
 
       // Cmd/Ctrl+H: Open find and replace
-      if (mod && key === "h" && hasSearch) {
+      if (matchesShortcut("FindAndReplace", e) && hasSearch) {
         e.preventDefault();
         setShowFind(true);
         setShowReplaceSection(true);
@@ -461,7 +459,7 @@ const VoidenEditorInner = ({
       }
 
       // Cmd/Ctrl+G: Find next (only when find panel is open)
-      if (mod && key === "g" && showFind && !e.shiftKey) {
+      if (matchesShortcut("FindNext", e) && showFind) {
         e.preventDefault();
         if (matchPositions.length > 0) {
           const nextIndex = (currentMatch + 1) % matchPositions.length;
@@ -471,7 +469,7 @@ const VoidenEditorInner = ({
       }
 
       // Shift+Cmd/Ctrl+G: Find previous (only when find panel is open)
-      if (mod && key === "g" && showFind && e.shiftKey) {
+      if (matchesShortcut("FindPrev", e) && showFind) {
         e.preventDefault();
         if (matchPositions.length > 0) {
           const prevIndex = (currentMatch - 1 + matchPositions.length) % matchPositions.length;

--- a/apps/ui/src/core/git/components/GitBranchesList.tsx
+++ b/apps/ui/src/core/git/components/GitBranchesList.tsx
@@ -7,6 +7,7 @@ import { useGetProjects } from "@/core/projects/hooks";
 import { toast } from "@/core/components/ui/sonner";
 import { Kbd } from "@/core/components/ui/kbd";
 import { Tip } from "@/core/components/ui/Tip";
+import { matchesShortcut, getShortcutLabel } from "@/core/shortcuts";
 
 type Step =
   | { type: "main" }
@@ -38,10 +39,7 @@ export const GitBranchesList = () => {
       const target = e.target as HTMLElement;
       if (target?.closest('.cm-editor, .txt-editor')) return;
 
-      const isMac = navigator.platform ? navigator.platform.toLowerCase().includes('mac') : false;
-      const modKey = isMac ? e.metaKey : e.ctrlKey;
-
-      if (e.code === "KeyB" && modKey && e.altKey) {
+      if (matchesShortcut("ToggleCheckoutBranch", e)) {
         e.preventDefault();
         setOpen((open) => !open);
       }
@@ -157,7 +155,7 @@ export const GitBranchesList = () => {
 
   return (
     <>
-      <Tip label={<span className="flex items-center gap-2"><span>Checkout branch</span><Kbd keys="⌥⌘B" size="sm" /></span>}>
+      <Tip label={<span className="flex items-center gap-2"><span>Checkout branch</span><Kbd keys={getShortcutLabel("ToggleCheckoutBranch")} size="sm" /></span>}>
         <button
           className={cn("text-sm h-full px-2 flex items-center gap-2 hover:bg-active no-drag text-comment", !data?.activeBranch && "text-comment")}
           onClick={() => setOpen(true)}

--- a/apps/ui/src/core/layout/components/EnvSelector.tsx
+++ b/apps/ui/src/core/layout/components/EnvSelector.tsx
@@ -7,6 +7,7 @@ import { useAddPanelTab, useActivateTab, useGetPanelTabs } from "@/core/layout/h
 import { ChevronRight, FileText, Ban, Check, Settings2, Layers } from "lucide-react";
 import { Kbd } from "@/core/components/ui/kbd";
 import { Tip } from "@/core/components/ui/Tip";
+import { matchesShortcut, getShortcutLabel } from "@/core/shortcuts";
 
 export const EnvSelector = () => {
   const queryClient = useQueryClient();
@@ -37,10 +38,7 @@ export const EnvSelector = () => {
       }
 
       // ⌥⌘E (Mac) or Alt+Ctrl+E (Windows/Linux) to toggle
-      const isMac = navigator.platform ? navigator.platform.toLowerCase().includes('mac') : false;
-      const modKey = isMac ? e.metaKey : e.ctrlKey;
-
-      if (e.code === "KeyE" && modKey && e.altKey) {
+      if (matchesShortcut("ToggleEnvSelector", e)) {
         e.preventDefault();
         setOpen((open) => !open);
       }
@@ -81,7 +79,7 @@ export const EnvSelector = () => {
       <div className="px-1">
         <ChevronRight size={14} className="text-comment" />
       </div>
-      <Tip label={<span className="flex items-center gap-2"><span>Select an environment</span><Kbd keys="⌥⌘E" size="sm" /></span>}>
+      <Tip label={<span className="flex items-center gap-2"><span>Select an environment</span><Kbd keys={getShortcutLabel("ToggleEnvSelector")} size="sm" /></span>}>
         <button
           className={cn("text-sm h-full px-2 flex items-center gap-2 hover:bg-active no-drag", !envs?.activeEnv && "text-comment")}
           onClick={() => setOpen(true)}
@@ -233,7 +231,7 @@ export const EnvSelector = () => {
                       Edit Environments & Profiles
                     </button>
                     <span className="flex items-center gap-1.5">
-                      <Kbd keys="⌥⌘E" size="sm" />
+                      <Kbd keys={getShortcutLabel("ToggleEnvSelector")} size="sm" />
                       <span className="text-sm">to toggle</span>
                     </span>
                   </div>

--- a/apps/ui/src/core/layout/components/PanelTabs.tsx
+++ b/apps/ui/src/core/layout/components/PanelTabs.tsx
@@ -20,7 +20,7 @@ import {
   Blocks,
   Terminal,
 } from "lucide-react";
-import { cn } from "@/core/lib/utils";
+import { cn, isMac } from "@/core/lib/utils";
 import { useActivateTab, useGetPanelTabs, useClosePanelTab, useDuplicatePanelTab, useReloadPanelTab, useSetTabsOrder, useClosePanelTabs } from "@/core/layout/hooks";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { useEditorStore } from "@/core/editors/voiden/VoidenEditor";
@@ -33,6 +33,7 @@ import { getQueryClient } from "@/main";
 import { Kbd } from "@/core/components/ui/kbd";
 import { Tip } from "@/core/components/ui/Tip";
 import { useSettings } from "@/core/settings/hooks/useSettings";
+import { matchesShortcut, getShortcutLabel } from "@/core/shortcuts";
 
 const PANEL_STATES_KEY = "panelStates";
 
@@ -243,7 +244,6 @@ const TabComponent = ({
     });
     closeTabs(panel, tabsClosed);
   };
-  const isMac = navigator.platform ? navigator.platform.toLowerCase().includes("mac") : false;
 
   const handleMouseDown = (e: React.MouseEvent) => {
     // Middle click
@@ -321,7 +321,7 @@ const TabComponent = ({
             {getTabIcon(tab)}
             <span className="truncate">{tab.title}</span>
           </div>
-          <Tip label={<><span>Close tab</span>{isActive && <span className="ml-4">{isMac ? "⌘W" : "Ctrl+W"}</span>}</>} side="bottom">
+          <Tip label={<><span>Close tab</span>{isActive && <span className="ml-4">{getShortcutLabel("CloseTab")}</span>}</>} side="bottom">
             <button className="p-0.5 hover:bg-active rounded-sm opacity-0 group-hover:opacity-100" onClick={handleClose}>
               <X size={14} className="text-comment" strokeWidth={2.5} />
             </button>
@@ -413,7 +413,6 @@ export const PanelTabs = ({ panel }: { panel: string }) => {
     }
     return unsaved;
   };
-  const isMac = navigator.platform ? navigator.platform.toLowerCase().includes("mac") : false;
 
   const transparentImage = new Image();
   transparentImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
@@ -548,7 +547,7 @@ export const PanelTabs = ({ panel }: { panel: string }) => {
 
       // Allow Cmd+W to work even in CodeMirror/txt editors
       // But block other shortcuts when in code editors
-      const isCloseTabShortcut = ((isMac && e.metaKey) || (!isMac && e.ctrlKey)) && e.key.toLowerCase() === "w";
+      const isCloseTabShortcut = matchesShortcut("CloseTab", e);
 
       if (isInCodeEditor && !isCloseTabShortcut) {
         return;
@@ -558,7 +557,7 @@ export const PanelTabs = ({ panel }: { panel: string }) => {
       if (panel !== "main" && panel !== "bottom") return;
 
       // Handle Reload Tab shortcut (Cmd/Ctrl + R)
-      if ((isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === "r") {
+      if (matchesShortcut("ReloadTab", e)) {
         e.preventDefault();
         if (tabs && tabs.activeTabId) {
           const activeTab = tabs.tabs.find((t: Tab) => t.id === tabs.activeTabId);
@@ -571,15 +570,7 @@ export const PanelTabs = ({ panel }: { panel: string }) => {
         return;
       }
 
-      const wPressedWithModifier = (isMac && e.metaKey) || (!isMac && e.ctrlKey);
-
-      if (wPressedWithModifier && e.key.toLowerCase() === "w") {
-        const hasOtherModifiers = (!isMac && e.metaKey) || (isMac && e.ctrlKey) || e.altKey || e.shiftKey;
-
-        if (hasOtherModifiers) {
-          return;
-        }
-
+      if (matchesShortcut("CloseTab", e)) {
         e.preventDefault();
 
         if (rPressed.current) {

--- a/apps/ui/src/core/layout/components/StatusBar.tsx
+++ b/apps/ui/src/core/layout/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { PanelLeft, Terminal, Github, MessageCircle, PanelRight, GitCompareArrows, Download, icons, Activity, X, GripHorizontal, Trash2, Logs } from "lucide-react";
-import { cn } from "@/core/lib/utils";
+import { cn, isMac } from "@/core/lib/utils";
 import { GitBranchesList } from "@/core/git/components/GitBranchesList";
 import { BranchComparisonDialog } from "@/core/git/components/BranchComparisonDialog";
 import { useSettings } from "@/core/settings/hooks/useSettings";
@@ -14,6 +14,7 @@ import { Kbd } from "@/core/components/ui/kbd";
 import { Tip } from "@/core/components/ui/Tip";
 import { usePluginStore } from "@/plugins";
 import type { StatusBarItem } from "@voiden/sdk/ui";
+import { matchesShortcut, getShortcutLabel } from "@/core/shortcuts";
 
 const handleExternalLink = (url: string) => (e: React.MouseEvent) => {
   e.preventDefault();
@@ -265,7 +266,6 @@ export const StatusBar = ({
   const [isCompareDialogOpen, setIsCompareDialogOpen] = useState(false);
   const [memStats, setMemStats] = useState<{ heap: number; processes: { type: string; mb: number; cpu: number }[] } | null>(null);
   const [updateProgress, setUpdateProgress] = useState<{ percent?: number; bytesPerSecond?: number; transferred?: number; total?: number; status: string } | null>(null);
-  const isMac = navigator?.userAgent?.toLowerCase().includes("mac") ?? false;
 
   const handleCheckForUpdates = async () => {
     if (isCheckingUpdates) return;
@@ -328,26 +328,14 @@ export const StatusBar = ({
         return;
       }
 
-      const modKey = isMac ? event.metaKey : event.ctrlKey;
-
-      if (event.code === "KeyD" && modKey && event.altKey) {
+      if (matchesShortcut("ToggleCompareBranches", event)) {
         event.preventDefault();
         setIsCompareDialogOpen((open) => !open);
         return;
       }
-      if (target?.closest('.cm-editor, .txt-editor')) {
-        return;
-      }
 
-      const modifierPressed = isMac ? event.metaKey : event.ctrlKey;
-
-      const hasOtherModifiers =
-        (isMac && event.ctrlKey) || // Ctrl on Mac
-        (!isMac && event.metaKey) || // Cmd on Windows/Linux
-        event.altKey ||
-        event.shiftKey;
-
-      if (modifierPressed && !hasOtherModifiers && event.key.toLowerCase() === 'b') {
+      // TODO: Duplicate shortcut for toggle sidebar?
+      if (matchesShortcut("ToggleSidebar", event)) {
         event.preventDefault();
         event.stopPropagation();
         toggleLeft();
@@ -355,14 +343,14 @@ export const StatusBar = ({
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [isMac]);
+  }, []);
 
   return (
     <>
     <div className="h-8 flex-none border-t border-border flex items-center justify-between bg-panel">
       {/* Left Status Items */}
       <div className="flex items-center h-full">
-        <Tip label={<span className="flex items-center gap-2"><span>Toggle left panel</span><Kbd keys={'⌘B'} size="sm" /></span>}>
+        <Tip label={<span className="flex items-center gap-2"><span>Toggle left panel</span><Kbd keys={getShortcutLabel("ToggleSidebar")} size="sm" /></span>}>
           <button className={cn("h-full px-2 hover:bg-active text-comment", !isLeftCollapsed && "bg-active")} onClick={toggleLeft}>
             <PanelLeft size={14} />
           </button>
@@ -370,7 +358,7 @@ export const StatusBar = ({
 
         <GitBranchesList />
 
-        <Tip label={<span className="flex items-center gap-2"><span>Compare branches</span><Kbd keys={'⌥⌘D'} size="sm" /></span>}>
+        <Tip label={<span className="flex items-center gap-2"><span>Compare branches</span><Kbd keys={getShortcutLabel("ToggleCompareBranches")} size="sm" /></span>}>
           <button
             className={cn("text-sm h-full px-2 flex items-center gap-2 hover:bg-active no-drag text-comment")}
             onClick={() => setIsCompareDialogOpen(true)}
@@ -537,7 +525,7 @@ export const StatusBar = ({
           </Tip>
 
           {/* Bottom Panel Toggle */}
-          <Tip label={<span className="flex items-center gap-2"><span>Toggle terminal</span><Kbd keys={'⌘J'} size="sm" /></span>} align="end">
+          <Tip label={<span className="flex items-center gap-2"><span>Toggle terminal</span><Kbd keys={getShortcutLabel("ToggleTerminal")} size="sm" /></span>} align="end">
             <button
               className={cn(
                 "h-full px-2 hover:bg-active text-comment",
@@ -588,7 +576,7 @@ export const StatusBar = ({
           </Tip>
 
           {/* Response Panel — open/close in current position */}
-          <Tip label={<span className="flex items-center gap-2"><span>Toggle response panel</span><Kbd keys={'⌘Y'} size="sm" /></span>} align="end">
+          <Tip label={<span className="flex items-center gap-2"><span>Toggle response panel</span><Kbd keys={getShortcutLabel("ToggleResponsePanel")} size="sm" /></span>} align="end">
             <button
               className={cn(
                 "h-full px-2 hover:bg-active text-comment",

--- a/apps/ui/src/core/layout/hooks/usePanels.ts
+++ b/apps/ui/src/core/layout/hooks/usePanels.ts
@@ -6,6 +6,7 @@ import { getResponsePanelPosition } from "@/core/stores/responsePanelPosition";
 import { useGetPanelTabs } from "./usePanelTabs";
 import { useNewTerminalTab } from "@/core/terminal/hooks";
 import { useGetAppState } from "@/core/state/hooks";
+import { matchesShortcut } from "@/core/shortcuts";
 
 const STORAGE_KEYS = {
   LEFT_PANEL: "novus:left-panel-collapsed",
@@ -44,8 +45,6 @@ export const useLeftPanel = ({ defaultSize = 20, minSize = 0 }: UseLeftPanelProp
 
   // Keyboard shortcut: Cmd+Shift+E
   useEffect(() => {
-    const isMac = navigator.userAgent ? navigator.userAgent.toLowerCase().includes("mac") : true;
-
     const handleKeyDown = (e: KeyboardEvent) => {
       // Don't trigger if focus is in a CodeMirror editor
       const target = e.target as HTMLElement;
@@ -53,9 +52,7 @@ export const useLeftPanel = ({ defaultSize = 20, minSize = 0 }: UseLeftPanelProp
         return;
       }
 
-      const key = e.key.toLowerCase();
-      const isSidebarShortcut = key === "e" && e.shiftKey && ((isMac && e.metaKey) || (!isMac && e.ctrlKey));
-
+      const isSidebarShortcut = matchesShortcut("ToggleExplorer", e);
       if (isSidebarShortcut) {
         e.preventDefault();
         toggle();
@@ -196,7 +193,7 @@ export const useBottomPanel = ({ defaultSize = 0, minSize = 20, panelId = "botto
         return;
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key === "j") {
+      if (matchesShortcut("ToggleTerminal", e)) {
         e.preventDefault();
         handleToggleBottomPanel();
       }
@@ -282,7 +279,7 @@ export const useRightPanel = ({ defaultSize = 0, minSize = 30 }: UseRightPanelPr
         return;
       }
 
-      if ((e.metaKey || e.ctrlKey) && e.key === "y") {
+      if (matchesShortcut("ToggleResponsePanel", e)) {
         e.preventDefault();
         const { setBottomActiveView, openBottomPanel, bottomPanelRef, bottomActiveView } = usePanelStore.getState();
         const responsePanelPosition = getResponsePanelPosition();

--- a/apps/ui/src/core/lib/utils.ts
+++ b/apps/ui/src/core/lib/utils.ts
@@ -28,3 +28,5 @@ export const getDocumentJSONFromBinary = (data: ArrayBuffer): JSONContent => {
     return {};
   }
 };
+
+export const isMac = window.electron?.platform === "darwin";

--- a/apps/ui/src/core/projects/components/RecentProjectsSelector.tsx
+++ b/apps/ui/src/core/projects/components/RecentProjectsSelector.tsx
@@ -5,8 +5,7 @@ import { useGetProjects, useSetActiveProject, removeProjectFromList } from "@/co
 import { X, Folder, Check } from "lucide-react";
 import { Kbd } from "@/core/components/ui/kbd";
 import { Tip } from "@/core/components/ui/Tip";
-
-const SHORTCUT_KEYS = "⌥⌘O";
+import { matchesShortcut, getShortcutLabel } from "@/core/shortcuts";
 
 export const RecentProjectsSelector = () => {
   const { data: projects, refetch } = useGetProjects();
@@ -14,12 +13,8 @@ export const RecentProjectsSelector = () => {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    const isMac = navigator.userAgent ? navigator.userAgent.toLowerCase().includes("mac") : true;
-
     const down = (e: KeyboardEvent) => {
-      const isToggleShortcut = e.code === "KeyO" && ((isMac && e.metaKey && e.altKey) || (!isMac && e.ctrlKey && e.altKey));
-
-      if (isToggleShortcut) {
+      if (matchesShortcut("ToggleRecentProjectsSelector", e)) {
         e.preventDefault();
         setOpen((open) => !open);
       }
@@ -52,7 +47,7 @@ export const RecentProjectsSelector = () => {
   if (!projects) return null;
   return (
     <>
-      <Tip label={<span className="flex items-center gap-2"><span>Open recent project</span><Kbd keys={SHORTCUT_KEYS} size="sm" /></span>}>
+      <Tip label={<span className="flex items-center gap-2"><span>Open recent project</span><Kbd keys={getShortcutLabel("ToggleRecentProjectsSelector")} size="sm" /></span>}>
         <button
           className={cn(
             "text-sm h-full px-2 flex items-center gap-2 hover:bg-active no-drag text-comment",
@@ -145,7 +140,7 @@ export const RecentProjectsSelector = () => {
                   <div className="flex items-center justify-between text-comment">
                     <span className="text-xs">Use ↑↓ to navigate • Enter to select</span>
                     <span className="flex items-center gap-1.5">
-                      <Kbd keys={SHORTCUT_KEYS} size="sm" />
+                      <Kbd keys={getShortcutLabel("ToggleRecentProjectsSelector")} size="sm" />
                       <span className="text-xs">to toggle</span>
                     </span>
                   </div>

--- a/apps/ui/src/core/shortcuts/__test__/shortcuts.test.ts
+++ b/apps/ui/src/core/shortcuts/__test__/shortcuts.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock isMac before importing the module under test
+let mockIsMac = true;
+vi.mock("@/core/lib/utils", () => ({
+  get isMac() {
+    return mockIsMac;
+  },
+}));
+
+function makeKeyEvent(
+  code: string,
+  mods: { meta?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean } = {},
+) {
+  return {
+    code,
+    metaKey: mods.meta ?? false,
+    ctrlKey: mods.ctrl ?? false,
+    altKey: mods.alt ?? false,
+    shiftKey: mods.shift ?? false,
+  } as KeyboardEvent;
+}
+
+describe("shortcuts", () => {
+  describe("mac", () => {
+    let matchesShortcut: typeof import("../index").matchesShortcut;
+    let getShortcutLabel: typeof import("../index").getShortcutLabel;
+
+    beforeEach(async () => {
+      mockIsMac = true;
+      vi.resetModules();
+      const mod = await import("../index");
+      matchesShortcut = mod.matchesShortcut;
+      getShortcutLabel = mod.getShortcutLabel;
+    });
+
+    describe("matchesShortcut", () => {
+      it("voiden test : matches ToggleSidebar with Cmd+B", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", { meta: true }))).toBe(true);
+      });
+
+      it("voiden test : rejects ToggleSidebar when extra modifiers are present", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", { meta: true, shift: true }))).toBe(false);
+      });
+
+      it("voiden test : rejects ToggleSidebar with Ctrl instead of Cmd on Mac", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", { ctrl: true }))).toBe(false);
+      });
+
+      it("voiden test : rejects when wrong key code", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyX", { meta: true }))).toBe(false);
+      });
+
+      it("voiden test : matches FindPrev with Cmd+Shift+G", () => {
+        expect(matchesShortcut("FindPrev", makeKeyEvent("KeyG", { meta: true, shift: true }))).toBe(true);
+      });
+
+      it("voiden test : distinguishes FindNext from FindPrev", () => {
+        const next = makeKeyEvent("KeyG", { meta: true });
+        const prev = makeKeyEvent("KeyG", { meta: true, shift: true });
+        expect(matchesShortcut("FindNext", next)).toBe(true);
+        expect(matchesShortcut("FindNext", prev)).toBe(false);
+        expect(matchesShortcut("FindPrev", prev)).toBe(true);
+        expect(matchesShortcut("FindPrev", next)).toBe(false);
+      });
+
+      it("voiden test : matches ToggleCheckoutBranch with Cmd+Alt+B", () => {
+        expect(matchesShortcut("ToggleCheckoutBranch", makeKeyEvent("KeyB", { meta: true, alt: true }))).toBe(true);
+      });
+
+      it("voiden test : matches ToggleCompareBranches with Cmd+Alt+Shift+D on Mac", () => {
+        expect(matchesShortcut("ToggleCompareBranches", makeKeyEvent("KeyD", { meta: true, alt: true, shift: true }))).toBe(true);
+      });
+
+      it("voiden test : rejects bare key with no modifiers", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", {}))).toBe(false);
+      });
+    });
+
+    describe("getShortcutLabel", () => {
+      it("voiden test : returns Mac symbols for simple shortcut", () => {
+        expect(getShortcutLabel("ToggleSidebar")).toBe("⌘B");
+      });
+
+      it("voiden test : returns Mac symbols with Shift", () => {
+        expect(getShortcutLabel("CommandPaletteCommands")).toBe("⇧⌘P");
+      });
+
+      it("voiden test : returns Mac symbols with Alt", () => {
+        expect(getShortcutLabel("ToggleCheckoutBranch")).toBe("⌥⌘B");
+      });
+
+      it("voiden test : returns Mac symbols with Alt+Shift", () => {
+        expect(getShortcutLabel("ToggleCompareBranches")).toBe("⇧⌥⌘D");
+      });
+    });
+  });
+
+  describe("non-mac", () => {
+    let matchesShortcut: typeof import("../index").matchesShortcut;
+    let getShortcutLabel: typeof import("../index").getShortcutLabel;
+
+    beforeEach(async () => {
+      mockIsMac = false;
+      vi.resetModules();
+      const mod = await import("../index");
+      matchesShortcut = mod.matchesShortcut;
+      getShortcutLabel = mod.getShortcutLabel;
+    });
+
+    describe("matchesShortcut", () => {
+      it("voiden test : matches ToggleSidebar with Ctrl+B", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", { ctrl: true }))).toBe(true);
+      });
+
+      it("voiden test : rejects ToggleSidebar with Cmd on non-Mac", () => {
+        expect(matchesShortcut("ToggleSidebar", makeKeyEvent("KeyB", { meta: true }))).toBe(false);
+      });
+
+      it("voiden test : matches ToggleCompareBranches with Ctrl+Alt+D on non-Mac", () => {
+        expect(matchesShortcut("ToggleCompareBranches", makeKeyEvent("KeyD", { ctrl: true, alt: true }))).toBe(true);
+      });
+    });
+
+    describe("getShortcutLabel", () => {
+      it("voiden test : returns text labels for simple shortcut", () => {
+        expect(getShortcutLabel("ToggleSidebar")).toBe("Ctrl+B");
+      });
+
+      it("voiden test : returns text labels with Shift", () => {
+        expect(getShortcutLabel("CommandPaletteCommands")).toBe("Shift+Ctrl+P");
+      });
+
+      it("voiden test : returns text labels with Alt", () => {
+        expect(getShortcutLabel("ToggleCheckoutBranch")).toBe("Ctrl+Alt+B");
+      });
+    });
+  });
+});

--- a/apps/ui/src/core/shortcuts/index.ts
+++ b/apps/ui/src/core/shortcuts/index.ts
@@ -1,0 +1,139 @@
+import { isMac } from "@/core/lib/utils";
+
+type Keybind = {
+  code: string;
+  modifiers: Modifiers;
+};
+
+enum Modifiers {
+  None = 0,
+  Alt = 1 << 0,
+  Ctrl = 1 << 1,
+  Meta = 1 << 2,
+  Shift = 1 << 3,
+}
+
+type Shortcut =
+  | "CloseTab"
+  | "CommandPaletteCommands"
+  | "CommandPaletteFiles"
+  | "Find"
+  | "FindAndReplace"
+  | "FindNext"
+  | "FindPrev"
+  | "NewFile"
+  | "NextTab"
+  | "PrevTab"
+  | "ReloadTab"
+  | "SendRequest"
+  | "ToggleCheckoutBranch"
+  | "ToggleCompareBranches"
+  | "ToggleExplorer"
+  | "ToggleEnvSelector"
+  | "ToggleRecentProjectsSelector"
+  | "ToggleResponsePanel"
+  | "ToggleSidebar"
+  | "ToggleTerminal";
+
+const primaryModifier = isMac ? Modifiers.Meta : Modifiers.Ctrl;
+
+const shortcuts = {
+  CloseTab: { code: "KeyW", modifiers: primaryModifier },
+  CommandPaletteCommands: {
+    code: "KeyP",
+    modifiers: primaryModifier | Modifiers.Shift,
+  },
+  CommandPaletteFiles: { code: "KeyP", modifiers: primaryModifier },
+  Find: {
+    code: "KeyF",
+    modifiers: primaryModifier,
+  },
+  FindAndReplace: {
+    code: "KeyH",
+    modifiers: primaryModifier,
+  },
+  FindNext: {
+    code: "KeyG",
+    modifiers: primaryModifier,
+  },
+  FindPrev: {
+    code: "KeyG",
+    modifiers: primaryModifier | Modifiers.Shift,
+  },
+  NewFile: {
+    code: "KeyN",
+    modifiers: primaryModifier,
+  },
+  NextTab: {
+    code: "BracketRight",
+    modifiers: primaryModifier | Modifiers.Shift,
+  },
+  PrevTab: {
+    code: "BracketLeft",
+    modifiers: primaryModifier | Modifiers.Shift,
+  },
+  ReloadTab: { code: "KeyR", modifiers: primaryModifier },
+  SendRequest: { code: "Enter", modifiers: primaryModifier },
+  ToggleCheckoutBranch: {
+    code: "KeyB",
+    modifiers: primaryModifier | Modifiers.Alt,
+  },
+  ToggleCompareBranches: {
+    code: "KeyD",
+    modifiers:
+      // On mac Meta + Alt + D collides with show/hide dock.
+      primaryModifier |
+      (isMac ? Modifiers.Alt | Modifiers.Shift : Modifiers.Alt),
+  },
+  ToggleExplorer: {
+    code: "KeyE",
+    modifiers: primaryModifier | Modifiers.Shift,
+  },
+  ToggleEnvSelector: {
+    code: "KeyE",
+    modifiers: primaryModifier | Modifiers.Alt,
+  },
+  ToggleRecentProjectsSelector: {
+    code: "KeyO",
+    modifiers: primaryModifier | Modifiers.Alt,
+  },
+  ToggleResponsePanel: { code: "KeyY", modifiers: primaryModifier },
+  ToggleSidebar: { code: "KeyB", modifiers: primaryModifier },
+  ToggleTerminal: { code: "KeyJ", modifiers: primaryModifier },
+} as const satisfies Record<Shortcut, Keybind>;
+
+export function getShortcutLabel(shortcut: Shortcut): string {
+  const bind = shortcuts[shortcut];
+  const parts: string[] = [];
+  if (bind.modifiers & Modifiers.Shift) parts.push(isMac ? "⇧" : "Shift+");
+  if (bind.modifiers & Modifiers.Ctrl) parts.push(isMac ? "⌃" : "Ctrl+");
+  if (bind.modifiers & Modifiers.Alt) parts.push(isMac ? "⌥" : "Alt+");
+  if (bind.modifiers & Modifiers.Meta) parts.push("⌘");
+
+  const keyLabel = bind.code
+    .replace("Key", "")
+    .replace("Digit", "")
+    .toUpperCase();
+  parts.push(keyLabel);
+  return parts.join("");
+}
+
+export function matchesShortcut(shortcut: Shortcut, event: KeyboardEvent) {
+  const keybind = shortcuts[shortcut];
+  if (event.code !== keybind.code) {
+    return false;
+  }
+
+  let modifiers = Modifiers.None;
+
+  if (event.altKey) modifiers |= Modifiers.Alt;
+  if (event.ctrlKey) modifiers |= Modifiers.Ctrl;
+  if (event.metaKey) modifiers |= Modifiers.Meta;
+  if (event.shiftKey) modifiers |= Modifiers.Shift;
+
+  if (modifiers !== keybind.modifiers) {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/ui/src/routes/__root.tsx
+++ b/apps/ui/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from "react";
 import { CommandPalette } from "@/core/components/CommandPalette";
 import { HelpModal } from "@/core/help/HelpModal";
 import { useHistoryTabSync } from "@/core/layout/hooks";
+import { matchesShortcut } from "@/core/shortcuts";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -27,7 +28,9 @@ export const Route = createRootRouteWithContext<{
     useEffect(() => {
       const handleKeyDown = (e: KeyboardEvent) => {
         // Cmd+P or Ctrl+P - check for both with and without shift
-        if ((e.metaKey || e.ctrlKey) && (e.key === 'p' || e.key === 'P')) {
+        const isCommandModeShortcut = matchesShortcut("CommandPaletteCommands", e);
+        const isFileModeShortcut = matchesShortcut("CommandPaletteFiles", e);
+        if (isCommandModeShortcut || isFileModeShortcut) {
           e.preventDefault();
 
           // Close help modal if it's open
@@ -35,7 +38,7 @@ export const Route = createRootRouteWithContext<{
             setHelpModalOpen(false);
           }
 
-          if (e.shiftKey) {
+          if (isCommandModeShortcut) {
             // Cmd+Shift+P - Command mode
             setPaletteMode('commands');
           } else {

--- a/apps/ui/src/types.d.ts
+++ b/apps/ui/src/types.d.ts
@@ -471,6 +471,7 @@ declare global {
         subscribe: (callback: (processes: any[]) => void) => () => void;
       };
     };
+    platform: NodeJS.Platform;
   }
 }
 


### PR DESCRIPTION
Replace ad-hoc shortcut handling scattered across components with a unified shortcuts registry using bitmask-based modifier matching and `event.code` for layout-independent key detection. Platform detection now uses `process.platform` via the Electron preload API instead of repeated `navigator.platform`/`navigator.userAgent` checks.