### PR TITLE
fix: don't call handleCopy on empty selection

### DIFF
--- a/apps/ui/src/core/shortcuts/index.ts
+++ b/apps/ui/src/core/shortcuts/index.ts
@@ -13,37 +13,19 @@ enum Modifiers {
   Shift = 1 << 3,
 }
 
-type Shortcut =
-  | "CloseTab"
-  | "CommandPaletteCommands"
-  | "CommandPaletteFiles"
-  | "Find"
-  | "FindAndReplace"
-  | "FindNext"
-  | "FindPrev"
-  | "NewFile"
-  | "NextTab"
-  | "PrevTab"
-  | "ReloadTab"
-  | "SendRequest"
-  | "ToggleCheckoutBranch"
-  | "ToggleCompareBranches"
-  | "ToggleExplorer"
-  | "ToggleEnvSelector"
-  | "ToggleRecentProjectsSelector"
-  | "ToggleResponsePanel"
-  | "ToggleSidebar"
-  | "ToggleTerminal";
-
 const primaryModifier = isMac ? Modifiers.Meta : Modifiers.Ctrl;
 
 const shortcuts = {
+  // Ctrl (not primaryModifier) is intentional: ctrl+L is the readline
+  // convention for clearing a terminal on all platforms, including macOS.
+  ClearTerminal: { code: "KeyL", modifiers: Modifiers.Ctrl },
   CloseTab: { code: "KeyW", modifiers: primaryModifier },
   CommandPaletteCommands: {
     code: "KeyP",
     modifiers: primaryModifier | Modifiers.Shift,
   },
   CommandPaletteFiles: { code: "KeyP", modifiers: primaryModifier },
+  Copy: { code: "KeyC", modifiers: primaryModifier },
   Find: {
     code: "KeyF",
     modifiers: primaryModifier,
@@ -68,11 +50,13 @@ const shortcuts = {
     code: "BracketRight",
     modifiers: primaryModifier | Modifiers.Shift,
   },
+  Paste: { code: "KeyV", modifiers: primaryModifier },
   PrevTab: {
     code: "BracketLeft",
     modifiers: primaryModifier | Modifiers.Shift,
   },
   ReloadTab: { code: "KeyR", modifiers: primaryModifier },
+  SelectAll: { code: "KeyA", modifiers: primaryModifier },
   SendRequest: { code: "Enter", modifiers: primaryModifier },
   ToggleCheckoutBranch: {
     code: "KeyB",
@@ -100,7 +84,9 @@ const shortcuts = {
   ToggleResponsePanel: { code: "KeyY", modifiers: primaryModifier },
   ToggleSidebar: { code: "KeyB", modifiers: primaryModifier },
   ToggleTerminal: { code: "KeyJ", modifiers: primaryModifier },
-} as const satisfies Record<Shortcut, Keybind>;
+} as const satisfies Record<string, Keybind>;
+
+type Shortcut = keyof typeof shortcuts;
 
 export function getShortcutLabel(shortcut: Shortcut): string {
   const bind = shortcuts[shortcut];

--- a/apps/ui/src/core/terminal/components/Terminal.tsx
+++ b/apps/ui/src/core/terminal/components/Terminal.tsx
@@ -7,6 +7,7 @@ import { useSettings } from "../../settings/hooks/useSettings";
 import { useNerdFont } from "../hooks/useNerdFont";
 import { useClosePanelTab, useGetPanelTabs } from "@/core/layout/hooks";
 import { usePanelStore } from "@/core/stores/panelStore";
+import { getShortcutLabel, matchesShortcut } from "@/core/shortcuts";
 
 interface TerminalProps {
   tabId: string;
@@ -263,19 +264,19 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
 
     xterm.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       if (e.type !== 'keydown') return true;
-      if ((e.ctrlKey || e.metaKey) && e.key === 'v') {
+      if (matchesShortcut("Paste", e)) {
         handlePaste();
         return false; // Prevent default browser behavior
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
+      if (matchesShortcut("SelectAll", e)) {
         handleSelectAll();
         return false;
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
+      if (matchesShortcut("Copy", e) && xterm.hasSelection()) {
         handleCopy();
         return false;
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === 'l') {
+      if (matchesShortcut("ClearTerminal", e)) {
         handleClear();
         return false;
       }
@@ -549,24 +550,24 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
       label: 'Copy',
       action: handleCopy,
       disabled: (xtermRef.current ? xtermRef.current.getSelection() : '').length == 0,
-      shortcut: 'Ctrl+C'
+      shortcut: getShortcutLabel('Copy')
     },
     {
       label: 'Paste',
       action: handlePaste,
-      shortcut: 'Ctrl+V'
+      shortcut: getShortcutLabel('Paste')
     },
     { separator: true },
     {
       label: 'Select All',
       action: handleSelectAll,
-      shortcut: 'Ctrl+A'
+      shortcut: getShortcutLabel('SelectAll')
     },
     { separator: true },
     {
       label: 'Clear Terminal',
       action: handleClear,
-      shortcut: 'Ctrl+L'
+      shortcut: getShortcutLabel('ClearTerminal')
     }
   ];
 


### PR DESCRIPTION
We were unconditionally calling handleCopy in the terminals key event handler when ctrl+c or meta+c were pressed. We now instead make sure that the user actually has something selected.

Note: this also changes terminal shortcut behavior. Previously checks were written as `(e.metaKey || e.ctrlKey) && e.key === ...`, accepting both modifiers interchangeably. We no longer accept both variants — the platform-appropriate modifier is now required.

Fixes VoidenHQ/voiden#281