### PR TITLE
Fix Lint Error Message Text Color

### DIFF
--- a/apps/ui/src/core/editors/code/lib/extensions/lintYaml.ts
+++ b/apps/ui/src/core/editors/code/lib/extensions/lintYaml.ts
@@ -113,6 +113,12 @@ export async function lintYaml(
             to: to,
             message: result.message,
             severity: "error",
+            renderMessage: () => {
+              const box = document.createElement('div');
+              box.style.cssText = 'color:var(--fg-primary)';
+              box.textContent = result.message;
+              return box;
+            },
           });
         });
       });


### PR DESCRIPTION
Added a rendering function for a YAML lint error message box with specifying the text style.
Resolves #333 