### PR TITLE
Invalidate YAML Environments On Project Switch

### DIFF
--- a/apps/electron/src/main/env.ts
+++ b/apps/electron/src/main/env.ts
@@ -425,8 +425,11 @@ ipcMain.handle("env:getYamlTrees", async (event, params?: { profile?: string }) 
   return { public: publicTree, private: privateTree };
 });
 
-ipcMain.handle("env:saveYamlTrees", async (event, { publicTree, privateTree, profile }: { publicTree: YamlEnvTree; privateTree: YamlEnvTree; profile?: string }) => {
-  const activeProject = await getActiveProject(event);
+ipcMain.handle("env:saveYamlTrees", async (event, { publicTree, privateTree, profile, projectPath }: { publicTree: YamlEnvTree; privateTree: YamlEnvTree; profile?: string; projectPath?: string }) => {
+  const appState = getAppState(event);
+  const activeProject = projectPath && appState.directories[projectPath]
+    ? projectPath
+    : await getActiveProject(event);
   if (!activeProject) return;
 
   // Ensure .voiden/ directory exists

--- a/apps/electron/src/preload/api/misc.ts
+++ b/apps/electron/src/preload/api/misc.ts
@@ -107,8 +107,8 @@ export const envApi = {
   getKeys: () => ipcRenderer.invoke("env:getKeys"),
   extendEnvs: (comment: string, variables: [{ key: string, value: string }]) => ipcRenderer.invoke('env:extend-env-files', { comment, variables }),
   getYamlTrees: (profile?: string) => ipcRenderer.invoke("env:getYamlTrees", profile ? { profile } : undefined) as Promise<{ public: Record<string, unknown>; private: Record<string, unknown> }>,
-  saveYamlTrees: (publicTree: Record<string, unknown>, privateTree: Record<string, unknown>, profile?: string) =>
-    ipcRenderer.invoke("env:saveYamlTrees", { publicTree, privateTree, profile }),
+  saveYamlTrees: (publicTree: Record<string, unknown>, privateTree: Record<string, unknown>, profile?: string, projectPath?: string) =>
+    ipcRenderer.invoke("env:saveYamlTrees", { publicTree, privateTree, profile, projectPath }),
   getProfiles: () => ipcRenderer.invoke("env:getProfiles") as Promise<string[]>,
   setActiveProfile: (profile: string) => ipcRenderer.invoke("env:setActiveProfile", profile),
   createProfile: (profile: string) => ipcRenderer.invoke("env:createProfile", profile),

--- a/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
+++ b/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
@@ -18,6 +18,7 @@ import {
   renameKey,
 } from "./envTreeUtils";
 import { useEditorStore } from "@/core/editors/voiden/VoidenEditor";
+import { useGetAppState } from "@/core/state/hooks";
 
 const DEBOUNCE_MS = 800;
 const PROFILE_NAME_REGEX = /^[a-z0-9][a-z0-9-]*$/;
@@ -988,6 +989,8 @@ const EnvSidebarItem = ({
 export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
   const queryClient = useQueryClient();
   const { data: envData } = useEnvironments();
+  const { data: appState } = useGetAppState();
+  const activeProject = appState?.activeDirectory ?? null;
   const [selectedProfile, setSelectedProfile] = useState<string>(
     rememberedProfile ?? envData?.activeProfile ?? "default"
   );
@@ -1035,6 +1038,7 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
   const dirtyRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const treeDataRef = useRef<EditableEnvTree>({});
+  const treeProjectRef = useRef<string | null>(null);
   const editorRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const setScrollPosition = useEditorStore((s) => s.setScrollPosition);
@@ -1089,6 +1093,20 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
   useEffect(() => { queryClient.invalidateQueries({ queryKey: ["yaml-environments"] }); }, [queryClient]);
   // Reset dirty on profile switch
   useEffect(() => { dirtyRef.current = false; }, [selectedProfile]);
+  // Reset on project switch
+  useEffect(() => {
+    if (treeProjectRef.current !== null && treeProjectRef.current !== activeProject) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      dirtyRef.current = false;
+      setTree({});
+      treeDataRef.current = {};
+      treeProjectRef.current = null;
+      setSelectedEnvPath(null);
+    }
+  }, [activeProject]);
 
   // Initialize tree from fetched data
   useEffect(() => {
@@ -1096,8 +1114,9 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
       const merged = mergeToEditable(data.public, data.private);
       setTree(merged);
       treeDataRef.current = merged;
+      treeProjectRef.current = activeProject;
     }
-  }, [data]);
+  }, [data, activeProject]);
 
   // Auto-select first env when tree loads
   useEffect(() => {
@@ -1133,17 +1152,22 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
+        const projectAtFlush = treeProjectRef.current;
+        if (!projectAtFlush) return;
         const { publicTree, privateTree } = splitFromEditable(treeDataRef.current);
-        saveRef.current({ publicTree, privateTree });
+        saveRef.current({ publicTree, privateTree, projectPath: projectAtFlush });
       }
     };
   }, []);
 
   const scheduleSave = useCallback((newTree: EditableEnvTree) => {
     if (timerRef.current) clearTimeout(timerRef.current);
+    const projectAtSchedule = treeProjectRef.current;
     timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      if (!projectAtSchedule) return;
       const { publicTree, privateTree } = splitFromEditable(newTree);
-      save({ publicTree, privateTree });
+      save({ publicTree, privateTree, projectPath: projectAtSchedule });
     }, DEBOUNCE_MS);
   }, [save]);
 

--- a/apps/ui/src/core/environment/hooks/useSaveYamlEnvironments.ts
+++ b/apps/ui/src/core/environment/hooks/useSaveYamlEnvironments.ts
@@ -5,8 +5,8 @@ import type { YamlEnvTree } from "./useYamlEnvironments.ts";
 export const useSaveYamlEnvironments = (profile?: string) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ publicTree, privateTree }: { publicTree: YamlEnvTree; privateTree: YamlEnvTree }) => {
-      await window.electron?.env.saveYamlTrees(publicTree, privateTree, profile);
+    mutationFn: async ({ publicTree, privateTree, projectPath }: { publicTree: YamlEnvTree; privateTree: YamlEnvTree; projectPath?: string }) => {
+      await window.electron?.env.saveYamlTrees(publicTree, privateTree, profile, projectPath);
     },
     onSuccess: () => {
       invalidateEnvQueries(queryClient);

--- a/apps/ui/src/core/environment/hooks/useYamlEnvironments.ts
+++ b/apps/ui/src/core/environment/hooks/useYamlEnvironments.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useGetAppState } from "@/core/state/hooks";
 
 export interface YamlEnvNode {
   intermediate?: boolean;
@@ -20,8 +21,10 @@ const loadYamlTrees = async (profile?: string): Promise<YamlEnvTrees> => {
 };
 
 export const useYamlEnvironments = (profile?: string) => {
+  const { data: appState } = useGetAppState();
+  const projectPath = appState?.activeDirectory ?? null;
   return useQuery({
-    queryKey: ["yaml-environments", profile],
+    queryKey: ["yaml-environments", projectPath, profile],
     queryFn: () => loadYamlTrees(profile),
     staleTime: Infinity,
   });

--- a/apps/ui/src/core/projects/hooks/useProjects.ts
+++ b/apps/ui/src/core/projects/hooks/useProjects.ts
@@ -57,6 +57,7 @@ export const useSetActiveProject = () => {
       queryClient.invalidateQueries({ queryKey: ["panel:tabs"] });
       queryClient.invalidateQueries({ queryKey: ["files:tree"] });
       queryClient.invalidateQueries({ queryKey: ["environments"] });
+      queryClient.invalidateQueries({ queryKey: ["yaml-environments"] });
     },
   });
 };

--- a/apps/ui/src/types.d.ts
+++ b/apps/ui/src/types.d.ts
@@ -383,6 +383,7 @@ declare global {
           publicTree: Record<string, unknown>,
           privateTree: Record<string, unknown>,
           profile?: string,
+          projectPath?: string,
         ) => Promise<void>;
         getProfiles: () => Promise<string[]>;
         setActiveProfile: (profile: string) => Promise<void>;


### PR DESCRIPTION
Added invalidation of the `yaml-environments` when project has been switched.

Closes #376.