### PR TITLE
fix: preserve large number precision in JSON response parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ AI Friendly:
 
 ## Install
 
-**Current version:** `1.6.1`
+**Current version:** `1.6.3`
 
 Download installers for macOS, Windows, and Linux from [voiden.md/download](https://voiden.md/download).
 Direct downloads are available for Apple Silicon and Intel macOS, Windows `.exe`, and Linux `.deb`, `.rpm`, and `.AppImage` builds.

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -109,6 +109,7 @@
     "immer": "^10.0.3",
     "js-base64": "^3.7.7",
     "js-cookie": "^3.0.5",
+    "lossless-json": "^4.0.2",
     "lucide-react": "^0.474.0",
     "marked": "^14.1.2",
     "next-themes": "^0.3.0",

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,23 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parse as losslessParse, stringify as losslessStringify, LosslessNumber } from "lossless-json";
+
+/**
+ * Custom number parser for lossless-json.
+ * Preserves numbers within safe integer range as native Numbers.
+ * Numbers exceeding Number.MAX_SAFE_INTEGER are kept as LosslessNumber
+ * to avoid IEEE 754 floating-point precision loss.
+ *
+ * @see https://github.com/VoidenHQ/voiden/issues/395
+ */
+function parseNumberSafe(value: string): number | LosslessNumber {
+  const num = Number(value);
+  if (Number.isInteger(num) && !Number.isSafeInteger(num)) {
+    return new LosslessNumber(value);
+  }
+  return num;
+}
 
 
 /**
@@ -414,7 +431,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = losslessParse(buffer.toString(), null, parseNumberSafe);
         } catch {
           body = buffer.toString();
         }
@@ -426,7 +443,7 @@ export async function sendRequestHybrid(
     }
 
     // Calculate size
-    const bodyString = typeof body === "string" ? body : JSON.stringify(body);
+    const bodyString = typeof body === "string" ? body : (losslessStringify(body) ?? "");
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     const endTime = performance.now();

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -2,11 +2,12 @@ import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
+import { parse as losslessParse, stringify as losslessStringify } from "lossless-json";
 
 export function prettifyJSON(json: string) {
   try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
+    const parsed = losslessParse(json);
+    return losslessStringify(parsed, null, 2) ?? json;
   } catch (error) {
     return json;
   }


### PR DESCRIPTION
Fixes #395

## Problem

When an API response contains integers exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1), JavaScript's native `JSON.parse()` silently rounds them to the nearest representable IEEE 754 double-precision float. For example, `174322306148984899` becomes `174322306148984900`.

This affects both the response body display and variable capture via `{{$res.body...}}`.

## Root Cause

In `sendRequestHybrid.ts`, the HTTP response buffer is parsed with `JSON.parse(buffer.toString())` at line 417. This is where precision loss first occurs. The rounded values then propagate through the entire response pipeline.

The `prettifyJSON` utility in `apps/ui/src/utils/index.ts` has the same issue.

## Fix

Uses [`lossless-json`](https://github.com/josdejong/lossless-json) to parse and stringify JSON without precision loss:

- **sendRequestHybrid.ts**: Replaced `JSON.parse()` with `losslessParse()` using a custom `parseNumberSafe` reviver that only wraps integers exceeding `MAX_SAFE_INTEGER` as `LosslessNumber` objects. Safe numbers remain native `Number` values.

- **apps/ui/src/utils/index.ts**: Updated `prettifyJSON` to use lossless parse/stringify.

- **apps/ui/package.json**: Added `lossless-json@^4.0.2` dependency.

## Notes

- The `ResponseBodyNode.tsx` component in `core-extensions` also uses `JSON.stringify` for display. A follow-up change there would complete the fix for the display layer.
- `lossless-json` is a well-maintained, zero-dependency library (~4KB gzipped).