### PR TITLE
Enhancement: add inline profile rename with double-click editing

### DIFF
--- a/apps/electron/src/main/env.ts
+++ b/apps/electron/src/main/env.ts
@@ -523,6 +523,25 @@ ipcMain.handle("env:deleteProfile", async (event, profile: string) => {
   }
 });
 
+ipcMain.handle("env:renameProfile", async (event, { oldName, newName }: { oldName: string; newName: string }) => {
+  const activeProject = await getActiveProject(event);
+  if (!activeProject || !oldName || oldName === "default") return;
+  if (!PROFILE_NAME_REGEX.test(oldName) || !PROFILE_NAME_REGEX.test(newName)) {
+    throw new Error(`Invalid profile name. Must match ${PROFILE_NAME_REGEX}`);
+  }
+  if (newName === "default") throw new Error('Cannot rename to "default"');
+  const { publicFile: oldPublic, privateFile: oldPrivate } = profileFileNames(oldName);
+  const { publicFile: newPublic, privateFile: newPrivate } = profileFileNames(newName);
+  try { await fs.rename(path.join(activeProject, oldPublic), path.join(activeProject, newPublic)); } catch { /* file may not exist */ }
+  try { await fs.rename(path.join(activeProject, oldPrivate), path.join(activeProject, newPrivate)); } catch { /* file may not exist */ }
+  // If renamed profile was active, update state
+  const appState = getAppState(event);
+  if (appState.directories[activeProject]?.activeProfile === oldName) {
+    appState.directories[activeProject].activeProfile = newName;
+    await saveState(appState);
+  }
+});
+
 // Simple handler to extend all .env files
 ipcMain.handle('env:extend-env-files', async (event, { comment, variables }) => {
   const activeProject = await getActiveProject(event);

--- a/apps/electron/src/preload/api/misc.ts
+++ b/apps/electron/src/preload/api/misc.ts
@@ -242,6 +242,8 @@ export const envApi = {
     ipcRenderer.invoke("env:createProfile", profile),
   deleteProfile: (profile: string) =>
     ipcRenderer.invoke("env:deleteProfile", profile),
+  renameProfile: (oldName: string, newName: string) =>
+    ipcRenderer.invoke("env:renameProfile", { oldName, newName }),
 };
 
 export const requestApi = {

--- a/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
+++ b/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
@@ -1027,6 +1027,12 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
     if (t === "default" || (profiles?.includes(t) && t !== selectedProfile)) { setProfileNameError("Profile already exists"); return; }
     renameProfile({ oldName: selectedProfile, newName: t }, {
       onSuccess: () => {
+        // Seed the new profile's cache key with existing data so useYamlEnvironments
+        // finds it immediately and skips the loading state (no flicker).
+        const existing = queryClient.getQueryData(["yaml-environments", activeProject, selectedProfile]);
+        if (existing) {
+          queryClient.setQueryData(["yaml-environments", activeProject, t], existing);
+        }
         setSelectedProfile(t);
         setEditingProfileName(false);
         setProfileNameError(null);
@@ -1473,35 +1479,41 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
       )}
       {/* Top toolbar */}
       <div className="flex items-center justify-between px-5 py-3 border-b border-border flex-shrink-0">
-        <div className="flex items-center gap-2">
-          <Settings2 size={15} style={{ color: "var(--icon-primary)" }} />
+        <div className="flex items-baseline gap-2">
+          <Settings2 size={15} style={{ color: "var(--icon-primary)" }} className="self-center" />
           <h2 className="text-sm font-semibold">Environments</h2>
           {selectedProfile !== "default" && (
-            editingProfileName ? (
-              <div className="flex flex-col">
-                <input
-                  ref={profileNameInputRef}
-                  value={profileNameValue}
-                  onChange={(e) => { setProfileNameValue(e.target.value); setProfileNameError(null); }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleProfileRenameCommit();
-                    if (e.key === "Escape") { setEditingProfileName(false); setProfileNameError(null); }
-                  }}
-                  onBlur={handleProfileRenameCommit}
-                  className="text-xs px-1.5 py-0.5 bg-editor border border-border rounded outline-none text-text w-28"
-                />
-                {profileNameError && (
-                  <span className="text-xs mt-0.5" style={{ color: "var(--icon-danger)" }}>{profileNameError}</span>
-                )}
-              </div>
-            ) : (
-              <span
-                className="text-xs text-comment/60 cursor-pointer select-none leading-none self-center"
-                onDoubleClick={() => { setProfileNameValue(selectedProfile); setEditingProfileName(true); }}
+            <div className="flex flex-col self-center">
+              <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-md border border-border text-comment select-none hover:bg-active transition-colors"
+                style={editingProfileName ? { borderColor: "var(--icon-primary)" } : undefined}
               >
-                · {selectedProfile}
+                <span className="text-comment/50">profile:</span>
+                {editingProfileName ? (
+                  <input
+                    ref={profileNameInputRef}
+                    value={profileNameValue}
+                    size={Math.max(profileNameValue.length, 1)}
+                    onChange={(e) => { setProfileNameValue(e.target.value); setProfileNameError(null); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleProfileRenameCommit();
+                      if (e.key === "Escape") { setEditingProfileName(false); setProfileNameError(null); }
+                    }}
+                    onBlur={handleProfileRenameCommit}
+                    className="bg-transparent outline-none text-text font-medium text-xs"
+                  />
+                ) : (
+                  <span
+                    className="text-text font-medium cursor-pointer"
+                    onDoubleClick={() => { setProfileNameValue(selectedProfile); setEditingProfileName(true); }}
+                  >
+                    {selectedProfile}
+                  </span>
+                )}
               </span>
-            )
+              {profileNameError && (
+                <span className="absolute top-full left-0 mt-1 text-xs px-2 py-0.5 rounded-md bg-panel border border-border whitespace-nowrap z-50" style={{ color: "var(--icon-danger)" }}>{profileNameError}</span>
+              )}
+            </div>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
+++ b/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
@@ -8,6 +8,7 @@ import { useSaveYamlEnvironments } from "@/core/environment/hooks";
 import { useProfiles } from "../hooks/useProfiles.ts";
 import { useCreateProfile } from "@/core/environment/hooks";
 import { useDeleteProfile } from "@/core/environment/hooks";
+import { useRenameProfile } from "@/core/environment/hooks";
 import type { EditableEnvNode, EditableVariable } from "./EnvironmentNode";
 import {
   type EditableEnvTree,
@@ -1010,6 +1011,28 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
   const profileParam = selectedProfile === "default" ? undefined : selectedProfile;
   const { data, isLoading } = useYamlEnvironments(profileParam);
   const { mutate: save } = useSaveYamlEnvironments(profileParam);
+  const { data: profiles } = useProfiles();
+  const { mutate: renameProfile } = useRenameProfile();
+  const [editingProfileName, setEditingProfileName] = useState(false);
+  const [profileNameValue, setProfileNameValue] = useState("");
+  const [profileNameError, setProfileNameError] = useState<string | null>(null);
+  const profileNameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { if (editingProfileName) profileNameInputRef.current?.focus(); }, [editingProfileName]);
+
+  const handleProfileRenameCommit = () => {
+    const t = profileNameValue.trim();
+    if (!t || t === selectedProfile) { setEditingProfileName(false); setProfileNameError(null); return; }
+    if (!PROFILE_NAME_REGEX.test(t)) { setProfileNameError("Lowercase letters, numbers, hyphens only"); return; }
+    if (t === "default" || (profiles?.includes(t) && t !== selectedProfile)) { setProfileNameError("Profile already exists"); return; }
+    renameProfile({ oldName: selectedProfile, newName: t }, {
+      onSuccess: () => {
+        setSelectedProfile(t);
+        setEditingProfileName(false);
+        setProfileNameError(null);
+      },
+    });
+  };
 
   const [tree, setTree] = useState<EditableEnvTree>({});
   const [selectedEnvPath, setSelectedEnvPath] = useState<string | null>(null);
@@ -1453,9 +1476,36 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
         <div className="flex items-center gap-2">
           <Settings2 size={15} style={{ color: "var(--icon-primary)" }} />
           <h2 className="text-sm font-semibold">Environments</h2>
+          {selectedProfile !== "default" && (
+            editingProfileName ? (
+              <div className="flex flex-col">
+                <input
+                  ref={profileNameInputRef}
+                  value={profileNameValue}
+                  onChange={(e) => { setProfileNameValue(e.target.value); setProfileNameError(null); }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleProfileRenameCommit();
+                    if (e.key === "Escape") { setEditingProfileName(false); setProfileNameError(null); }
+                  }}
+                  onBlur={handleProfileRenameCommit}
+                  className="text-xs px-1.5 py-0.5 bg-editor border border-border rounded outline-none text-text w-28"
+                />
+                {profileNameError && (
+                  <span className="text-xs mt-0.5" style={{ color: "var(--icon-danger)" }}>{profileNameError}</span>
+                )}
+              </div>
+            ) : (
+              <span
+                className="text-xs text-comment/60 cursor-pointer select-none leading-none self-center"
+                onDoubleClick={() => { setProfileNameValue(selectedProfile); setEditingProfileName(true); }}
+              >
+                · {selectedProfile}
+              </span>
+            )
+          )}
         </div>
         <div className="flex items-center gap-2">
-          <ProfileSelector selectedProfile={selectedProfile} onSelectProfile={(p) => { setSelectedProfile(p); setSelectedEnvPath(null); }} />
+          <ProfileSelector selectedProfile={selectedProfile} onSelectProfile={(p) => { setSelectedProfile(p); setSelectedEnvPath(null); setEditingProfileName(false); }} />
         </div>
       </div>
 

--- a/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
+++ b/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
@@ -1483,7 +1483,7 @@ export const EnvironmentEditor = ({ tabId }: { tabId: string }) => {
           <Settings2 size={15} style={{ color: "var(--icon-primary)" }} className="self-center" />
           <h2 className="text-sm font-semibold">Environments</h2>
           {selectedProfile !== "default" && (
-            <div className="flex flex-col self-center">
+            <div className="relative flex flex-col self-center">
               <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-md border border-border text-comment select-none hover:bg-active transition-colors"
                 style={editingProfileName ? { borderColor: "var(--icon-primary)" } : undefined}
               >

--- a/apps/ui/src/core/environment/hooks/index.ts
+++ b/apps/ui/src/core/environment/hooks/index.ts
@@ -20,6 +20,7 @@ export { useProfiles } from "./useProfiles";
 export { useSetActiveProfile } from "./useSetActiveProfile";
 export { useCreateProfile } from "./useCreateProfile";
 export { useDeleteProfile } from "./useDeleteProfile";
+export { useRenameProfile } from "./useRenameProfile";
 
 export type { EnvironmentData } from "./useEnvironments";
 export type { YamlEnvNode, YamlEnvTree, YamlEnvTrees } from "./useYamlEnvironments.ts";

--- a/apps/ui/src/core/environment/hooks/useRenameProfile.ts
+++ b/apps/ui/src/core/environment/hooks/useRenameProfile.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { invalidateEnvQueries } from "./envQueryKeys";
+
+export const useRenameProfile = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ oldName, newName }: { oldName: string; newName: string }) => {
+      await window.electron?.env.renameProfile(oldName, newName);
+    },
+    onSuccess: () => {
+      invalidateEnvQueries(queryClient);
+    },
+  });
+};

--- a/apps/ui/src/core/environment/hooks/useRenameProfile.ts
+++ b/apps/ui/src/core/environment/hooks/useRenameProfile.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { invalidateEnvQueries } from "./envQueryKeys";
 
 export const useRenameProfile = () => {
   const queryClient = useQueryClient();
@@ -8,7 +7,7 @@ export const useRenameProfile = () => {
       await window.electron?.env.renameProfile(oldName, newName);
     },
     onSuccess: () => {
-      invalidateEnvQueries(queryClient);
+      queryClient.invalidateQueries({ queryKey: ["env-profiles"] });
     },
   });
 };

--- a/apps/ui/src/types.d.ts
+++ b/apps/ui/src/types.d.ts
@@ -398,6 +398,7 @@ declare global {
         setActiveProfile: (profile: string) => Promise<void>;
         createProfile: (profile: string) => Promise<void>;
         deleteProfile: (profile: string) => Promise<void>;
+        renameProfile: (oldName: string, newName: string) => Promise<void>;
       };
       fileLink: {
         exists: (absolutePath: string) => Promise<boolean>;


### PR DESCRIPTION

## Summary
Closes #399

- Adds `profile: <name>` badge in Environments header for non-default profiles
- Double-click the name to rename inline; Enter or blur saves, Escape cancels
- No layout shift on validation error, no flicker on save

## Test plan
- [ ] Double-click badge → input appears, `profile:` label stays
- [ ] Valid rename → saves on disk, header + dropdown update, no flicker
- [ ] Invalid name / duplicate → error tooltip below badge, no layout shift
- [ ] Escape → cancels with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
