### PR TITLE
fix(request-engine): preserve large JSON integers in API responses

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so API variables stay exact.
+ * Fixes VoidenHQ/voiden#395.
+ */
+export function parseJsonPreserveIntegers(text: string): unknown {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const asNumber = Number(digits);
+      return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.parse(normalized);
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +66,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -46,10 +46,22 @@ export interface ResponseBodyAttrs {
 
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+function prettifyJsonText(text: string): string {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+}
+
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary

Fixes [#395](https://github.com/VoidenHQ/voiden/issues/395): large integers in JSON responses were rounded by `JSON.parse`, corrupting `{{$res.body...}}` variables and the response viewer.

- `parseJsonPreserveIntegers()` — unsafe integers stored as decimal strings
- Used in `requestState.ts` response parsing and `runtimeVariables` JSON navigation
- JSON prettify in `ResponseBodyNode` uses the same preservation for raw text

## Test plan

- [x] `yarn workspace @voiden/ui test src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts --run`
- [ ] POST large integer to echo API; confirm `174322306148984899` is exact in UI and variables

Closes #395

Made with [Cursor](https://cursor.com)