### PR TITLE
Edit/rename environment profile

### DIFF
--- a/apps/electron/src/main/env.ts
+++ b/apps/electron/src/main/env.ts
@@ -504,6 +504,45 @@ ipcMain.handle("env:createProfile", async (event, profile: string) => {
   try { const { ensureVoidenGitignore } = await import('./git'); await ensureVoidenGitignore(activeProject); } catch { }
 });
 
+ipcMain.handle("env:renameProfile", async (event, oldName: string, newName: string) => {
+  const activeProject = await getActiveProject(event);
+  if (!activeProject || !oldName || !newName || oldName === "default" || newName === "default") {
+    throw new Error("Cannot rename the default profile or use reserved name");
+  }
+  if (!PROFILE_NAME_REGEX.test(oldName) || !PROFILE_NAME_REGEX.test(newName)) {
+    throw new Error(`Invalid profile name. Must match ${PROFILE_NAME_REGEX}`);
+  }
+  if (oldName === newName) return;
+
+  const profiles = await discoverProfiles(activeProject);
+  if (!profiles.includes(oldName)) {
+    throw new Error(`Profile "${oldName}" does not exist`);
+  }
+  if (profiles.includes(newName)) {
+    throw new Error(`Profile "${newName}" already exists`);
+  }
+
+  const oldFiles = profileFileNames(oldName);
+  const newFiles = profileFileNames(newName);
+  const renames: [string, string][] = [
+    [path.join(activeProject, oldFiles.publicFile), path.join(activeProject, newFiles.publicFile)],
+    [path.join(activeProject, oldFiles.privateFile), path.join(activeProject, newFiles.privateFile)],
+  ];
+  for (const [from, to] of renames) {
+    try {
+      await fs.rename(from, to);
+    } catch (e: any) {
+      if (e.code !== "ENOENT") throw e;
+    }
+  }
+
+  const appState = getAppState(event);
+  if (appState.directories[activeProject]?.activeProfile === oldName) {
+    appState.directories[activeProject].activeProfile = newName;
+    await saveState(appState);
+  }
+});
+
 ipcMain.handle("env:deleteProfile", async (event, profile: string) => {
   const activeProject = await getActiveProject(event);
   if (!activeProject || !profile || profile === "default") return;

--- a/apps/electron/src/preload/api/misc.ts
+++ b/apps/electron/src/preload/api/misc.ts
@@ -163,6 +163,8 @@ export const envApi = {
     ipcRenderer.invoke("env:createProfile", profile),
   deleteProfile: (profile: string) =>
     ipcRenderer.invoke("env:deleteProfile", profile),
+  renameProfile: (oldName: string, newName: string) =>
+    ipcRenderer.invoke("env:renameProfile", oldName, newName),
 };
 
 export const requestApi = {

--- a/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
+++ b/apps/ui/src/core/environment/components/EnvironmentEditor.tsx
@@ -8,6 +8,7 @@ import { useSaveYamlEnvironments } from "@/core/environment/hooks";
 import { useProfiles } from "../hooks/useProfiles.ts";
 import { useCreateProfile } from "@/core/environment/hooks";
 import { useDeleteProfile } from "@/core/environment/hooks";
+import { useRenameProfile } from "@/core/environment/hooks/useRenameProfile.ts";
 import type { EditableEnvNode, EditableVariable } from "./EnvironmentNode";
 import {
   type EditableEnvTree,
@@ -150,8 +151,10 @@ const ProfileSelector = ({
   const { data: profiles } = useProfiles();
   const { mutate: createProfile } = useCreateProfile();
   const { mutate: deleteProfile } = useDeleteProfile();
+  const { mutate: renameProfile } = useRenameProfile();
   const [open, setOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [renaming, setRenaming] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
   const [nameError, setNameError] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -161,7 +164,7 @@ const ProfileSelector = ({
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false); setCreating(false); setNewName(""); setNameError(null);
+        setOpen(false); setCreating(false); setRenaming(null); setNewName(""); setNameError(null);
       }
     };
     if (open) document.addEventListener("mousedown", handler);
@@ -175,6 +178,19 @@ const ProfileSelector = ({
     if (t === "default" || profiles?.includes(t)) { setNameError("Profile already exists"); return; }
     createProfile(t); onSelectProfile(t);
     setCreating(false); setNewName(""); setNameError(null); setOpen(false);
+  };
+
+  const handleRename = () => {
+    const t = newName.trim();
+    if (!renaming || !t) return;
+    if (!PROFILE_NAME_REGEX.test(t)) { setNameError("Lowercase letters, numbers, hyphens only"); return; }
+    if (t === "default" || (profiles?.includes(t) && t !== renaming)) {
+      setNameError("Profile already exists");
+      return;
+    }
+    renameProfile({ oldName: renaming, newName: t });
+    if (selectedProfile === renaming) onSelectProfile(t);
+    setRenaming(null); setNewName(""); setNameError(null); setOpen(false);
   };
 
   return (
@@ -191,26 +207,57 @@ const ProfileSelector = ({
           <div className="px-3 py-1.5 text-xs text-comment font-semibold uppercase tracking-wider border-b border-border">Profile</div>
           <div className="max-h-40 overflow-y-auto py-1">
             {profiles?.map((p) => (
-              <div
-                key={p}
-                className="flex items-center px-3 py-1.5 text-sm hover:bg-active cursor-pointer group"
-                onClick={() => { onSelectProfile(p); setOpen(false); }}
-              >
-                <span className="flex-1 truncate">{p}</span>
-                {p === selectedProfile && <Check size={13} style={{ color: "var(--icon-success)" }} />}
-                {p !== "default" && (
-                  <button
-                    className="p-0.5 rounded hover:bg-border opacity-0 group-hover:opacity-100 ml-1"
-                    onClick={(e) => { e.stopPropagation(); deleteProfile(p); if (selectedProfile === p) onSelectProfile("default"); setOpen(false); }}
-                  >
-                    <Trash2 size={11} className="text-comment" />
-                  </button>
-                )}
-              </div>
+              renaming === p ? (
+                <div key={p} className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    ref={inputRef}
+                    value={newName}
+                    onChange={(e) => { setNewName(e.target.value); setNameError(null); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRename();
+                      if (e.key === "Escape") { setRenaming(null); setNewName(""); setNameError(null); }
+                    }}
+                    className="w-full text-sm px-2 py-1 bg-editor border border-border rounded outline-none text-text"
+                  />
+                  {nameError && <p className="text-xs mt-1" style={{ color: "var(--icon-danger)" }}>{nameError}</p>}
+                </div>
+              ) : (
+                <div
+                  key={p}
+                  className="flex items-center px-3 py-1.5 text-sm hover:bg-active cursor-pointer group"
+                  onClick={() => { onSelectProfile(p); setOpen(false); }}
+                >
+                  <span className="flex-1 truncate">{p}</span>
+                  {p === selectedProfile && <Check size={13} style={{ color: "var(--icon-success)" }} />}
+                  {p !== "default" && (
+                    <>
+                      <button
+                        className="p-0.5 rounded hover:bg-border opacity-0 group-hover:opacity-100 ml-1"
+                        title="Rename profile"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setRenaming(p);
+                          setNewName(p);
+                          setCreating(false);
+                          setNameError(null);
+                        }}
+                      >
+                        <Pencil size={11} className="text-comment" />
+                      </button>
+                      <button
+                        className="p-0.5 rounded hover:bg-border opacity-0 group-hover:opacity-100 ml-1"
+                        onClick={(e) => { e.stopPropagation(); deleteProfile(p); if (selectedProfile === p) onSelectProfile("default"); setOpen(false); }}
+                      >
+                        <Trash2 size={11} className="text-comment" />
+                      </button>
+                    </>
+                  )}
+                </div>
+              )
             ))}
           </div>
           <div className="border-t border-border px-3 py-2">
-            {creating ? (
+            {creating && !renaming ? (
               <div>
                 <input
                   ref={inputRef}
@@ -222,11 +269,11 @@ const ProfileSelector = ({
                 />
                 {nameError && <p className="text-xs mt-1" style={{ color: "var(--icon-danger)" }}>{nameError}</p>}
               </div>
-            ) : (
-              <button onClick={() => setCreating(true)} className="flex items-center gap-1.5 text-sm text-comment hover:text-text w-full">
+            ) : !renaming ? (
+              <button onClick={() => { setCreating(true); setNewName(""); }} className="flex items-center gap-1.5 text-sm text-comment hover:text-text w-full">
                 <Plus size={13} /> New profile
               </button>
-            )}
+            ) : null}
           </div>
         </div>
       )}

--- a/apps/ui/src/core/environment/hooks/useRenameProfile.ts
+++ b/apps/ui/src/core/environment/hooks/useRenameProfile.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useRenameProfile() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ oldName, newName }: { oldName: string; newName: string }) => {
+      await window.electron?.env.renameProfile(oldName, newName);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["profiles"] });
+      queryClient.invalidateQueries({ queryKey: ["yaml-environments"] });
+    },
+  });
+}

--- a/apps/ui/src/types.d.ts
+++ b/apps/ui/src/types.d.ts
@@ -390,6 +390,7 @@ declare global {
         setActiveProfile: (profile: string) => Promise<void>;
         createProfile: (profile: string) => Promise<void>;
         deleteProfile: (profile: string) => Promise<void>;
+        renameProfile: (oldName: string, newName: string) => Promise<void>;
       };
       fileLink: {
         exists: (absolutePath: string) => Promise<boolean>;


### PR DESCRIPTION
## Summary

- Add `env:renameProfile` IPC to rename non-default profile YAML files
- Expose rename in the Environment profile dropdown (pencil icon + inline edit)
- Keep active profile selection in sync when renaming the selected profile

Closes #399

## Test plan

- [ ] Create a named profile, rename it via pencil control, confirm env files renamed under `.voiden/`
- [ ] Rename the active profile and confirm variables still load
- [ ] Verify `default` cannot be renamed
