### PR TITLE
fix: GraphQL variable pairing and JSON integer precision

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so API variables stay exact.
+ * Fixes VoidenHQ/voiden#395.
+ */
+export function parseJsonPreserveIntegers(text: string): unknown {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const asNumber = Number(digits);
+      return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.parse(normalized);
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString('utf-8'));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +66,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -11,6 +11,7 @@ import { Request, BaseResponse } from "@/core/types";
 import { RestApiRequestState, RestApiResponseState } from "./pipeline/types";
 import { hookRegistry, PipelineStage } from "./pipeline";
 import { Buffer } from "buffer";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables } from "./runtimeVariables";
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGraphQLBlocks } from './graphqlBlocks';
+
+describe('resolveGraphQLBlocks', () => {
+  it('pairs variables with the last gqlquery in a multi-request document', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"a":1}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q3');
+    expect(variablesNode?.attrs?.body).toBe('{"c":3}');
+  });
+
+  it('finds variables before the query when listed above it', () => {
+    const content = [
+      { type: 'gqlvariables', attrs: { body: '{"x":9}' } },
+      { type: 'gqlquery', attrs: { uid: 'only' } },
+    ];
+    const { variablesNode } = resolveGraphQLBlocks(content);
+    expect(variablesNode?.attrs?.body).toBe('{"x":9}');
+  });
+
+  it('pairs variables with the middle gqlquery when scoped to that section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+
+  it('does not pair variables from a different query section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"first":true}' } },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"second":true}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"second":true}');
+  });
+});

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
@@ -1,0 +1,64 @@
+export interface GraphQLContentNode {
+  type?: string;
+  attrs?: { body?: string; [key: string]: unknown };
+  content?: GraphQLContentNode[];
+}
+
+export interface GraphQLBlockPair {
+  queryNode: GraphQLContentNode | undefined;
+  variablesNode: GraphQLContentNode | undefined;
+}
+
+/**
+ * Pair gqlvariables with the last gqlquery in the active section.
+ */
+export function resolveGraphQLBlocks(
+  content: GraphQLContentNode[] | undefined,
+): GraphQLBlockPair {
+  if (!content?.length) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  const queries = content.filter((n) => n.type === 'gqlquery');
+  if (queries.length === 0) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  const queryNode = queries[queries.length - 1];
+  const qIdx = content.indexOf(queryNode);
+  let variablesNode: GraphQLContentNode | undefined;
+
+  for (let i = qIdx + 1; i < content.length; i++) {
+    if (content[i].type === 'gqlquery') break;
+    if (content[i].type === 'gqlvariables') {
+      variablesNode = content[i];
+      break;
+    }
+  }
+
+  if (!variablesNode) {
+    for (let i = qIdx - 1; i >= 0; i--) {
+      if (content[i].type === 'gqlquery') break;
+      if (content[i].type === 'gqlvariables') {
+        variablesNode = content[i];
+        break;
+      }
+    }
+  }
+
+  return { queryNode, variablesNode };
+}
+
+export function parseGraphQLVariablesBody(
+  body: string | undefined,
+): Record<string, unknown> {
+  if (!body?.trim()) return {};
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/core-extensions/src/voiden-graphql/plugin.ts
+++ b/core-extensions/src/voiden-graphql/plugin.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PluginContext } from '@voiden/sdk/ui';
+import { parseGraphQLVariablesBody, resolveGraphQLBlocks } from './lib/graphqlBlocks';
 import { parseGraphQLOperation } from './lib/utils';
 import manifest from './manifest.json';
 
@@ -77,9 +78,8 @@ export default function createGraphQLPlugin(context: PluginContext) {
           // Environment variables will be replaced securely in Electron (Stage 3)
           // Faker variables will be replaced at Stage 5 (Pre-Send) by the faker extension
           request = await getRequest(editorJson, undefined, undefined);
-          // Only handle documents with a gqlquery node
-          const gqlNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlquery'
+          const { queryNode: gqlNode, variablesNode: gqlVariablesNode } = resolveGraphQLBlocks(
+            editorJson.content,
           );
           if (!gqlNode) return request; // Not a GraphQL doc, pass through
 
@@ -98,18 +98,7 @@ export default function createGraphQLPlugin(context: PluginContext) {
             operationName = match[2];
           }
 
-          // Get variables from gqlvariables block
-          const gqlVariablesNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlvariables'
-          );
-          let variables: any = {};
-          if (gqlVariablesNode) {
-            try {
-              variables = JSON.parse(gqlVariablesNode.attrs?.body || '{}');
-            } catch (e) {
-              // ignore parse errors
-            }
-          }
+          const variables = parseGraphQLVariablesBody(gqlVariablesNode?.attrs?.body);
 
           // URL: from gqlurl child text, or legacy attrs.endpoint, or schemaUrl
           const gqlUrlText = gqlUrlChild?.content?.[0]?.text || gqlUrlChild?.content || '';

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -46,10 +46,22 @@ export interface ResponseBodyAttrs {
 
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+function prettifyJsonText(text: string): string {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+}
+
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary
- Pair GraphQL variables with the active query in multi-request files instead of always using the first block (#391)
- Preserve large JSON integers in response parsing so runtime variables and the response viewer stay exact (#395)

Addresses feedback from #256.

## Test plan
- [x] `yarn test core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts --run`
- [x] `yarn workspace voiden-ui test src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts --run`
- [ ] Multi-request GraphQL file: send third request and confirm correct variables payload
- [ ] POST large integer to echo API; confirm exact value in UI and `{{$res.body...}}` variables

Closes #256
Closes #391
Closes #395