### PR TITLE
fix(request-engine): preserve large JSON integers in responses

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonPreserveIntegers, prettifyJsonText } from "../parseJsonPreserveIntegers";
+
+/** JSON.parse rounds this id; issue #408 requires the exact decimal string. */
+const LARGE_ID = "174322306148984899";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings (#408)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      `{"args":{"id":${LARGE_ID}}}`,
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe(LARGE_ID);
+    expect(JSON.parse(`{"args":{"id":${LARGE_ID}}}`).args.id).not.toBe(LARGE_ID);
+  });
+
+  it("preserves a trailing large integer before closing brace", () => {
+    const parsed = parseJsonPreserveIntegers(`{"id":${LARGE_ID}}`) as {
+      id: string;
+    };
+    expect(parsed.id).toBe(LARGE_ID);
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+    expect(typeof parsed.count).toBe("number");
+  });
+
+  it("keeps MAX_SAFE_INTEGER as a number", () => {
+    const max = String(Number.MAX_SAFE_INTEGER);
+    const parsed = parseJsonPreserveIntegers(`{"n":${max}}`) as { n: number };
+    expect(parsed.n).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers(`{"id":"${LARGE_ID}"}`) as {
+      id: string;
+    };
+    expect(parsed.id).toBe(LARGE_ID);
+  });
+
+  it("prettifyJsonText shows large integers without rounding", () => {
+    const pretty = prettifyJsonText(`{"args":{"id":${LARGE_ID}}}`);
+    expect(pretty).toContain(LARGE_ID);
+    expect(pretty).not.toContain("174322306148984900");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so response display and
+ * runtime variables (e.g. {{$res.body...}}) stay exact.
+ * Fixes VoidenHQ/voiden#408.
+ */
+const UNSAFE_INTEGER_LITERAL =
+  /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g;
+
+function quoteUnsafeIntegerLiterals(text: string): string {
+  return text.replace(UNSAFE_INTEGER_LITERAL, (digits) => {
+    const asNumber = Number(digits);
+    return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+  });
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerLiterals(text));
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Prettify raw JSON text for viewers without losing large integers. */
+export function prettifyJsonText(text: string): string {
+  return stringifyJsonForDisplay(parseJsonPreserveIntegers(text));
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -66,7 +67,7 @@ function safeJsonParse(value: any): any {
 
     try {
         // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +80,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -156,7 +157,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonPreserveIntegers(value);
                 } catch {
                     current=value;
                 }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -12,6 +12,7 @@ import { RestApiRequestState, RestApiResponseState } from "./pipeline/types";
 import { hookRegistry, PipelineStage } from "./pipeline";
 import { Buffer } from "buffer";
 import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -2,11 +2,11 @@ import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
+import { prettifyJsonText } from "@/core/request-engine/parseJsonPreserveIntegers";
 
 export function prettifyJSON(json: string) {
   try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
+    return prettifyJsonText(json);
   } catch (error) {
     return json;
   }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -13,6 +13,7 @@ import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { AlertCircle, Check, ChevronDown, Copy, Download, Eye, FileDown, FileText, WrapText } from "lucide-react";
 
+import { prettifyJsonText } from "@/core/request-engine/parseJsonPreserveIntegers";
 type LangOption = { label: string; value: string };
 const LANG_OPTIONS: LangOption[] = [
   { label: "Auto", value: "auto" },
@@ -49,7 +50,7 @@ const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript",
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary
- Parse API JSON response bodies with `parseJsonPreserveIntegers` so integers beyond `Number.MAX_SAFE_INTEGER` are kept as exact decimal strings instead of being rounded by `JSON.parse`.
- Use the same logic when resolving `{{$res.body...}}` runtime variables and when prettifying JSON in the response viewer and shared `prettifyJSON` helper.
- Add unit tests covering the #408 scenario (large `id` in nested JSON).

## Test plan
- [x] `cd apps/ui && yarn test run parseJsonPreserveIntegers`
- [ ] Send a request whose JSON body contains an integer larger than `Number.MAX_SAFE_INTEGER` and confirm the response viewer shows the full digits.
- [ ] Capture `{{$res.body...}}` for that field and confirm the runtime variable matches the API value.

Closes #408