### PR TITLE
fix: preserve large integer precision in JSON response parsing

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -109,6 +109,7 @@
     "immer": "^10.0.3",
     "js-base64": "^3.7.7",
     "js-cookie": "^3.0.5",
+    "lossless-json": "^4.0.2",
     "lucide-react": "^0.474.0",
     "marked": "^14.1.2",
     "next-themes": "^0.3.0",

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonLossless, stringifyJsonLossless } from '@/utils/losslessJson';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString());
         } catch {
           body = buffer.toString();
         }
@@ -233,7 +234,7 @@ export class HybridPipelineExecutor {
     }
 
     // Calculate size
-    const bodyString = typeof body === 'string' ? body : JSON.stringify(body);
+    const bodyString = typeof body === 'string' ? body : stringifyJsonLossless(body);
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     return {

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonLossless } from "@/utils/losslessJson";
 
 export interface EnvironmentVariable {
   key: string;
@@ -311,7 +312,8 @@ async function parseBody(response: Response): Promise<Buffer | string | object |
   // JSON
   if (contentType.includes("json")) {
     try {
-      return await response.json();
+      const text = await response.text();
+      return parseJsonLossless(text);
     } catch (e) {
       return await response.text(); // fallback if parsing fails
     }
@@ -332,7 +334,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonLossless(bytes.toString());
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +821,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString());
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,9 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import {
+  losslessValueToString,
+  parseJsonLossless,
+  stringifyJsonLossless,
+} from "@/utils/losslessJson";
 
 interface RuntimeVariable {
     key: string;
@@ -66,7 +71,7 @@ function safeJsonParse(value: any): any {
 
     try {
         // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonLossless(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +84,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonLossless(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -156,7 +161,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonLossless(value);
                 } catch {
                     current=value;
                 }
@@ -274,9 +279,7 @@ function replaceTemplateExpressions(
         // Replace the expression with the actual value
         if (extractedValue !== undefined && extractedValue !== null) {
             // Convert to string for replacement
-            const stringValue = typeof extractedValue === 'object'
-                ? JSON.stringify(extractedValue)
-                : String(extractedValue);
+            const stringValue = losslessValueToString(extractedValue);
 
             result = result.replace(expression, stringValue);
         } else {
@@ -372,7 +375,7 @@ function replaceProcessVariables(text: string, variables: Record<string, any>, p
 
         if (value !== undefined && value !== null) {
             // Convert to string for replacement
-            return typeof value === 'object' ? JSON.stringify(value) : String(value);
+            return losslessValueToString(value);
         } else {
             // If variable not found, keep the original expression or replace with empty string
             console.warn(`Process variable not found: ${trimmedPath}`);
@@ -468,10 +471,10 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
                 }
             } else if (typeof requestState.body === 'object') {
                 // Body is already parsed as JSON, stringify -> replace -> parse back
-                const bodyString = JSON.stringify(requestState.body);
+                const bodyString = stringifyJsonLossless(requestState.body);
                 const replacedString = replaceProcessVariables(bodyString, processVariables);
                 try {
-                    requestState.body = JSON.parse(replacedString);
+                    requestState.body = parseJsonLossless(replacedString);
                 } catch (e) {
                     // If parsing fails, keep as string
                     requestState.body = replacedString;
@@ -495,7 +498,7 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
                     // Convert to string for form params (they're always strings in HTTP)
                     return {
                         ...param,
-                        value: typeof replacedValue === 'object' ? JSON.stringify(replacedValue) : String(replacedValue),
+                        value: losslessValueToString(replacedValue),
                     };
                 } else {
                     // Multiple templates or mixed text

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,7 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parseJsonLossless, stringifyJsonLossless } from "@/utils/losslessJson";
 
 
 /**
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString());
         } catch {
           body = buffer.toString();
         }
@@ -426,7 +427,7 @@ export async function sendRequestHybrid(
     }
 
     // Calculate size
-    const bodyString = typeof body === "string" ? body : JSON.stringify(body);
+    const bodyString = typeof body === "string" ? body : stringifyJsonLossless(body);
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     const endTime = performance.now();

--- a/apps/ui/src/utils/__test__/losslessJson.test.ts
+++ b/apps/ui/src/utils/__test__/losslessJson.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  losslessValueToString,
+  parseJsonLossless,
+  prettifyJsonLossless,
+  stringifyJsonLossless,
+} from "../losslessJson";
+
+describe("losslessJson", () => {
+  it("preserves large integers without rounding", () => {
+    const json = '{"id":174322306148984899}';
+    const parsed = parseJsonLossless(json) as { id: bigint };
+
+    expect(typeof parsed.id).toBe("bigint");
+    expect(parsed.id).toBe(174322306148984899n);
+    expect(parsed.id.toString()).toBe("174322306148984899");
+    expect(parsed.id.toString()).not.toBe("174322306148984900");
+
+    const serialized = stringifyJsonLossless(parsed);
+    expect(serialized).toContain("174322306148984899");
+    expect(serialized).not.toContain("174322306148984900");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonLossless('{"count":42,"ratio":1.5}') as {
+      count: number;
+      ratio: number;
+    };
+
+    expect(typeof parsed.count).toBe("number");
+    expect(parsed.count).toBe(42);
+    expect(typeof parsed.ratio).toBe("number");
+    expect(parsed.ratio).toBe(1.5);
+  });
+
+  it("prettifies JSON without losing large integer precision", () => {
+    const input = '{"id":174322306148984899,"name":"test"}';
+    const prettified = prettifyJsonLossless(input);
+
+    expect(prettified).toContain("174322306148984899");
+    expect(prettified).not.toContain("174322306148984900");
+
+    const roundTrip = parseJsonLossless(prettified) as { id: bigint; name: string };
+    expect(roundTrip.id).toBe(174322306148984899n);
+    expect(roundTrip.name).toBe("test");
+  });
+
+  it("stringifies values for template replacement without rounding", () => {
+    const value = { id: 174322306148984899n };
+    expect(losslessValueToString(value)).toBe('{"id":174322306148984899}');
+  });
+
+  it("preserves nested large integers from issue #395 fixture", () => {
+    const json = '{"args":{"id":174322306148984899}}';
+    const parsed = parseJsonLossless(json) as { args: { id: bigint } };
+
+    expect(parsed.args.id).toBe(174322306148984899n);
+    expect(losslessValueToString(parsed.args.id)).toBe("174322306148984899");
+  });
+});

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -3,13 +3,10 @@ import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
 
+import { prettifyJsonLossless } from "./losslessJson";
+
 export function prettifyJSON(json: string) {
-  try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
-  } catch (error) {
-    return json;
-  }
+  return prettifyJsonLossless(json);
 }
 
 export const getFileIfNotExist = async (docId: string, fileId: string, fileName: string): Promise<File | null> => {

--- a/apps/ui/src/utils/losslessJson.ts
+++ b/apps/ui/src/utils/losslessJson.ts
@@ -1,0 +1,58 @@
+import {
+  isInteger,
+  isLosslessNumber,
+  isSafeNumber,
+  parse,
+  stringify,
+} from "lossless-json";
+
+/**
+ * Parse a JSON numeric token without losing precision for integers outside
+ * Number.MAX_SAFE_INTEGER. Safe integers remain numbers; larger integers become bigint.
+ */
+export function parseNumberSafe(value: string): number | bigint {
+  if (isInteger(value) && isSafeNumber(value)) {
+    return Number(value);
+  }
+  if (isInteger(value)) {
+    return BigInt(value);
+  }
+  return Number(value);
+}
+
+/**
+ * Parse JSON text while preserving large integer precision.
+ */
+export function parseJsonLossless(text: string): unknown {
+  return parse(text, undefined, parseNumberSafe);
+}
+
+/**
+ * Stringify JSON values, including bigint and LosslessNumber instances.
+ */
+export function stringifyJsonLossless(value: unknown, space?: number | string): string {
+  return stringify(value, null, space) ?? "";
+}
+
+/**
+ * Parse and re-format JSON with indentation, preserving large integer precision.
+ */
+export function prettifyJsonLossless(json: string): string {
+  try {
+    return stringifyJsonLossless(parseJsonLossless(json), 2);
+  } catch {
+    return json;
+  }
+}
+
+/**
+ * Convert a parsed JSON value to a string without rounding large integers.
+ */
+export function losslessValueToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isLosslessNumber(value)) return value.toString();
+  return stringifyJsonLossless(value);
+}

--- a/core-extensions/package.json
+++ b/core-extensions/package.json
@@ -54,6 +54,7 @@
     "@faker-js/faker": "^9.0.3",
     "@voiden/sdk": "^1.0.9",
     "js-yaml": "^4.1.0",
+    "lossless-json": "^4.0.2",
     "selfsigned": "^5.5.0",
     "shell-quote": "^1.8.1",
     "xlsx-js-style": "^1.2.0"

--- a/core-extensions/src/utils/losslessJson.ts
+++ b/core-extensions/src/utils/losslessJson.ts
@@ -1,0 +1,42 @@
+import {
+  isInteger,
+  isLosslessNumber,
+  isSafeNumber,
+  parse,
+  stringify,
+} from "lossless-json";
+
+export function parseNumberSafe(value: string): number | bigint {
+  if (isInteger(value) && isSafeNumber(value)) {
+    return Number(value);
+  }
+  if (isInteger(value)) {
+    return BigInt(value);
+  }
+  return Number(value);
+}
+
+export function parseJsonLossless(text: string): unknown {
+  return parse(text, undefined, parseNumberSafe);
+}
+
+export function stringifyJsonLossless(value: unknown, space?: number | string): string {
+  return stringify(value, null, space) ?? "";
+}
+
+export function prettifyJsonLossless(json: string): string {
+  try {
+    return stringifyJsonLossless(parseJsonLossless(json), 2);
+  } catch {
+    return json;
+  }
+}
+
+export function losslessValueToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isLosslessNumber(value)) return value.toString();
+  return stringifyJsonLossless(value);
+}

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { AlertCircle, Check, ChevronDown, Copy, Download, Eye, FileDown, FileText, WrapText } from "lucide-react";
+import { losslessValueToString, prettifyJsonLossless, stringifyJsonLossless } from "../../utils/losslessJson";
 
 type LangOption = { label: string; value: string };
 const LANG_OPTIONS: LangOption[] = [
@@ -49,7 +50,7 @@ const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript",
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonLossless(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);
@@ -167,11 +168,11 @@ export const createResponseBodyNode = (
       }
       let text: string;
       if (isJson) {
-        text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        text = typeof body === "string" ? body : stringifyJsonLossless(body, 2);
       } else if (isXml || isHtml || isText) {
         text = typeof body === "string" ? body : String(body);
       } else if (typeof body === "object") {
-        text = JSON.stringify(body, null, 2);
+        text = stringifyJsonLossless(body, 2);
       } else {
         text = String(body);
       }
@@ -261,7 +262,7 @@ export const createResponseBodyNode = (
           const uint8Array = new Uint8Array(body.data);
           blob = new Blob([uint8Array as any], { type: contentType || "application/octet-stream" });
         } else {
-          blob = new Blob([JSON.stringify(body, null, 2)], { type: "application/json" });
+          blob = new Blob([stringifyJsonLossless(body, 2)], { type: "application/json" });
         }
 
         const url = URL.createObjectURL(blob);
@@ -281,7 +282,7 @@ export const createResponseBodyNode = (
     // Copy handler
     const handleCopy = async () => {
       try {
-        const textToCopy = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        const textToCopy = typeof body === "string" ? body : losslessValueToString(body);
         await navigator.clipboard.writeText(textToCopy);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -615,7 +616,7 @@ export const createResponseBodyNode = (
       if (typeof body === "object" && body.type === "Buffer" && Array.isArray(body.data)) {
         return new Uint8Array(body.data);
       }
-      return new TextEncoder().encode(typeof body === "string" ? body : JSON.stringify(body, null, 2));
+      return new TextEncoder().encode(typeof body === "string" ? body : losslessValueToString(body));
     };
 
     // Render hex dump view

--- a/yarn.lock
+++ b/yarn.lock
@@ -9195,6 +9195,7 @@ __metadata:
     "@types/shell-quote": "npm:^1.7.1"
     "@voiden/sdk": "npm:^1.0.9"
     js-yaml: "npm:^4.1.0"
+    lossless-json: "npm:^4.0.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     sass: "npm:^1.89.2"
@@ -15540,6 +15541,13 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 10c0/655d110220983c1a4b9c0c679a2e8016d4b67f6e9c7b5435ff5979ecdb20d0813f4dec0a08674fcbdd4846a3f07edbb50a36811fd37930b94aaa0d9daceb017e
+  languageName: node
+  linkType: hard
+
+"lossless-json@npm:^4.0.2":
+  version: 4.3.0
+  resolution: "lossless-json@npm:4.3.0"
+  checksum: 10c0/b561eb7f77ef99dbaa0df32fa2407ddcc2c61a0d53297240f0fdd6c2e5f2e0f7d224fb055f84e76467f5ec65547540662c265fcf7a1705497a2d44e323c517df
   languageName: node
   linkType: hard
 
@@ -22210,6 +22218,7 @@ __metadata:
     js-base64: "npm:^3.7.7"
     js-cookie: "npm:^3.0.5"
     jsdom: "npm:^27.3.0"
+    lossless-json: "npm:^4.0.2"
     lucide-react: "npm:^0.474.0"
     marked: "npm:^14.1.2"
     next-themes: "npm:^0.3.0"


### PR DESCRIPTION
## Summary
- Replace `JSON.parse`/`JSON.stringify` with `lossless-json` utilities for JSON response parsing, display, and runtime variable extraction
- Large integers (e.g. `174322306148984899`) are preserved as `bigint` instead of being rounded to `174322306148984900`
- Safe integers remain native `number` types for compatibility
- Also fixes the fetch-based `parseBody` path that used `response.json()` (same rounding issue)

## Root cause
JavaScript's `JSON.parse` converts numeric tokens to IEEE 754 doubles. Integers beyond `Number.MAX_SAFE_INTEGER` (9007199254740991) lose precision. This affected response body parsing in `sendRequestHybrid.ts`, `requestState.ts`, `HybridPipelineExecutor.ts`, response display in `ResponseBodyNode.tsx`, and runtime variable capture via `{{$res.body.*}}`.

## Test plan
- [x] Regression tests in `apps/ui/src/utils/__test__/losslessJson.test.ts` — large integer preservation, safe integer types, prettify round-trip, issue #395 fixture
- [ ] Send a request whose JSON response contains an integer > `Number.MAX_SAFE_INTEGER` and verify the response body displays the exact value
- [ ] Capture a large integer from a response into a runtime variable (`{{$res.body.parsedBody.args.id}}`) and confirm it is stored without rounding

Closes #395

Made with [Cursor](https://cursor.com)