### PR TITLE
fix(request-engine): preserve large JSON integers in responses

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonPreserveIntegers, prettifyJsonText } from "../parseJsonPreserveIntegers";
+
+const LARGE_ID = "333333333333333333";
+const LARGE_ID_395 = "174322306148984899";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings (#408)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      `{"response":[{"big_number_id":${LARGE_ID}}]}`,
+    ) as { response: Array<{ big_number_id: string }> };
+    expect(parsed.response[0].big_number_id).toBe(LARGE_ID);
+    expect(
+      JSON.parse(`{"response":[{"big_number_id":${LARGE_ID}}]}`).response[0]
+        .big_number_id,
+    ).not.toBe(LARGE_ID);
+  });
+
+  it("preserves nested large integers (#395)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      `{"args":{"id":${LARGE_ID_395}}}`,
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe(LARGE_ID_395);
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+    expect(typeof parsed.count).toBe("number");
+  });
+
+  it("keeps MAX_SAFE_INTEGER as a number", () => {
+    const max = String(Number.MAX_SAFE_INTEGER);
+    const parsed = parseJsonPreserveIntegers(`{"n":${max}}`) as { n: number };
+    expect(parsed.n).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers(`{"id":"${LARGE_ID}"}`) as {
+      id: string;
+    };
+    expect(parsed.id).toBe(LARGE_ID);
+  });
+
+  it("prettifyJsonText shows large integers without rounding", () => {
+    const pretty = prettifyJsonText(`{"big_number_id":${LARGE_ID}}`);
+    expect(pretty).toContain(LARGE_ID);
+    expect(pretty).not.toContain("333333333333333300");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,28 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so response display and
+ * runtime variables (e.g. {{$res.body...}}) stay exact.
+ * Fixes VoidenHQ/voiden#408.
+ */
+const UNSAFE_INTEGER_LITERAL =
+  /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g;
+
+function quoteUnsafeIntegerLiterals(text: string): string {
+  return text.replace(UNSAFE_INTEGER_LITERAL, (digits) => {
+    const asNumber = Number(digits);
+    return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+  });
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerLiterals(text));
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/** Prettify raw JSON text for viewers without losing large integers. */
+export function prettifyJsonText(text: string): string {
+  return stringifyJsonForDisplay(parseJsonPreserveIntegers(text));
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString("utf-8"));
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +66,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +79,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -156,7 +156,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonPreserveIntegers(value);
                 } catch {
                     current=value;
                 }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -12,6 +12,7 @@ import { RestApiRequestState, RestApiResponseState } from "./pipeline/types";
 import { hookRegistry, PipelineStage } from "./pipeline";
 import { Buffer } from "buffer";
 import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -2,11 +2,11 @@ import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
+import { prettifyJsonText } from "@/core/request-engine/parseJsonPreserveIntegers";
 
 export function prettifyJSON(json: string) {
   try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
+    return prettifyJsonText(json);
   } catch (error) {
     return json;
   }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -46,10 +46,22 @@ export interface ResponseBodyAttrs {
 
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+function prettifyJsonText(text: string): string {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+}
+
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary
- Add `parseJsonPreserveIntegers` to quote JSON integer literals beyond `Number.MAX_SAFE_INTEGER` before `JSON.parse`, preventing IEEE 754 rounding.
- Use the helper when parsing HTTP response bodies (`sendRequestHybrid`, `requestState`, `HybridPipelineExecutor`), resolving `{{$res.body...}}` runtime variables, and prettifying JSON in the response viewer.
- Add regression tests for the #408 snowflake ID scenario (`333333333333333333`).

## Test plan
- [x] `npx vitest run apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts`
- [ ] Execute a request returning a JSON body with an integer larger than `Number.MAX_SAFE_INTEGER` and confirm the response viewer shows exact digits.
- [ ] Capture the value via `{{$res.body...}}` and confirm the runtime variable matches the API response.

Closes #408

Made with [Cursor](https://cursor.com)