### PR TITLE
fix: prevent exception when typing ``` and pressing Enter in void files

### DIFF
--- a/apps/ui/src/core/editors/voiden/__test__/customCodeBlockInputRule.test.ts
+++ b/apps/ui/src/core/editors/voiden/__test__/customCodeBlockInputRule.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+vi.mock("@/core/editors/code/lib/components/CodeEditor", () => ({
+  CodeEditor: () => null,
+}));
+
+vi.mock("@/core/editors/voiden/nodes/RequestBlockHeader", () => ({
+  RequestBlockHeader: () => null,
+}));
+
+vi.mock("@/core/settings/hooks", () => ({
+  useSettings: () => ({ settings: {} }),
+}));
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { CustomCodeBlock } from "@/core/editors/voiden/nodes/CustomCodeBlock";
+
+const TestCustomCodeBlock = CustomCodeBlock.extend({
+  addNodeView: undefined,
+});
+
+const createEditor = (content: string) =>
+  new Editor({
+    element: document.createElement("div"),
+    extensions: [
+      StarterKit.configure({
+        codeBlock: false,
+      }),
+      TestCustomCodeBlock,
+    ],
+    content,
+  });
+
+const triggerCodeBlockInputRule = (editor: Editor) => {
+  editor.commands.focus("end");
+  editor.view.someProp("handleKeyDown", (handler) =>
+    handler(
+      editor.view,
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    ),
+  );
+};
+
+describe("CustomCodeBlock input rules", () => {
+  let editor: Editor;
+
+  afterEach(() => {
+    editor?.destroy();
+  });
+
+  it("voiden test : converts ``` + Enter to codeBlock without throwing", () => {
+    editor = createEditor("<p>```</p>");
+
+    expect(() => triggerCodeBlockInputRule(editor)).not.toThrow();
+
+    const doc = editor.getJSON();
+    expect(doc.content?.[0]?.type).toBe("codeBlock");
+    expect(doc.content?.[0]?.attrs?.language).toBe("plaintext");
+    expect(doc.content?.[0]?.attrs?.body).toBe("");
+  });
+
+  it("voiden test : ```javascript + Enter creates codeBlock with language javascript", () => {
+    editor = createEditor("<p>```javascript</p>");
+
+    triggerCodeBlockInputRule(editor);
+
+    const doc = editor.getJSON();
+    expect(doc.content?.[0]?.type).toBe("codeBlock");
+    expect(doc.content?.[0]?.attrs?.language).toBe("javascript");
+    expect(doc.content?.[0]?.attrs?.body).toBe("");
+  });
+});

--- a/apps/ui/src/core/editors/voiden/nodes/CustomCodeBlock.tsx
+++ b/apps/ui/src/core/editors/voiden/nodes/CustomCodeBlock.tsx
@@ -1,5 +1,9 @@
-import { mergeAttributes, NodeViewProps } from "@tiptap/core";
-import CodeBlock from "@tiptap/extension-code-block";
+import { InputRule, mergeAttributes, NodeViewProps } from "@tiptap/core";
+import CodeBlock, {
+  backtickInputRegex,
+  tildeInputRegex,
+} from "@tiptap/extension-code-block";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
 import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import { CodeEditor } from "@/core/editors/code/lib/components/CodeEditor";
 import { RequestBlockHeader } from "@/core/editors/voiden/nodes/RequestBlockHeader";
@@ -112,6 +116,93 @@ export const CustomCodeBlock = CodeBlock.extend({
         },
       },
     };
+  },
+
+  addInputRules() {
+    const createCodeBlockInputRule = (find: RegExp) =>
+      new InputRule({
+        find,
+        handler: ({ state, range, match }) => {
+          const $start = state.doc.resolve(range.from);
+          const depth = $start.depth;
+
+          if (
+            !$start
+              .node(depth - 1)
+              .canReplaceWith(
+                $start.index(depth - 1),
+                $start.indexAfter(depth - 1),
+                this.type,
+              )
+          ) {
+            return null;
+          }
+
+          const language = match[1] || "plaintext";
+
+          state.tr.replaceWith(
+            $start.before(depth),
+            $start.after(depth),
+            this.type.create({ language, body: "" }),
+          );
+        },
+      });
+
+    return [
+      createCodeBlockInputRule(backtickInputRegex),
+      createCodeBlockInputRule(tildeInputRegex),
+    ];
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("codeBlockVSCodeHandler"),
+        props: {
+          handlePaste: (view, event) => {
+            if (!event.clipboardData) {
+              return false;
+            }
+
+            if (this.editor.isActive(this.type.name)) {
+              return false;
+            }
+
+            const text = event.clipboardData.getData("text/plain");
+            const vscode = event.clipboardData.getData("vscode-editor-data");
+            const vscodeData = vscode ? JSON.parse(vscode) : undefined;
+            const language = vscodeData?.mode;
+
+            if (!text || !language) {
+              return false;
+            }
+
+            const { tr } = view.state;
+
+            tr.replaceSelectionWith(
+              this.type.create({
+                language,
+                body: text.replace(/\r\n?/g, "\n"),
+              }),
+            );
+
+            if (tr.selection.$from.parent.type !== this.type) {
+              tr.setSelection(
+                TextSelection.near(
+                  tr.doc.resolve(Math.max(0, tr.selection.from - 2)),
+                ),
+              );
+            }
+
+            tr.setMeta("paste", true);
+
+            view.dispatch(tr);
+
+            return true;
+          },
+        },
+      }),
+    ];
   },
 
   addNodeView() {


### PR DESCRIPTION
## Summary
- Fixes `RangeError: Type given to setBlockType should be a textblock` when typing ` ``` ` and pressing Enter in a `.void` file
- `CustomCodeBlock` stores code in `attrs.body` with `content: ""`, so the inherited TipTap `textblockTypeInputRule` (which calls `setBlockType`) was invalid for this node type
- Adds custom input rules that replace the paragraph with a `codeBlock` node via `replaceWith`, and updates the VS Code paste handler to store pasted code in `attrs.body`

## Test plan
- [x] `yarn workspace voiden-ui test --run customCodeBlockInputRule` — verifies ` ``` ` + Enter and ` ```javascript ` + Enter create code blocks without throwing
- [ ] Manually type ` ``` ` in a void file and press Enter — should insert an empty code block instead of throwing

Closes #400