### PR TITLE
fix(request-engine): preserve large JSON integers in responses and runtime vars

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+
+  it("preserves large IDs in nested response arrays (#408)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"response":[{"big_number_id":333333333333333333}]}',
+    ) as { response: Array<{ big_number_id: string }> };
+    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  });
+
+  it("preserves string-serialized large IDs in nested response arrays (#408)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"response":[{"big_number_id":"333333333333333333"}]}',
+    ) as { response: Array<{ big_number_id: string }> };
+    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  });
+});

--- a/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { saveRuntimeVariables } from "../runtimeVariables";
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
+
+describe("runtime variables with large integers", () => {
+  const mergeVariables = vi.fn().mockResolvedValue(undefined);
+  const getActiveEnvKey = vi.fn().mockResolvedValue("default");
+  const updateGitignore = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).window = {
+      electron: {
+        variables: { mergeVariables, getActiveEnvKey },
+        git: { updateGitignore },
+      },
+    };
+  });
+
+  it("captures large response IDs without rounding (#408)", async () => {
+    const rawBody = '{"response":[{"big_number_id":333333333333333333}]}';
+    const resObject = {
+      body: parseJsonPreserveIntegers(rawBody),
+    };
+
+    await saveRuntimeVariables(
+      undefined,
+      resObject,
+      [
+        {
+          key: "big_number_id",
+          value: "{{$res.body.response[0].big_number_id}}",
+          enabled: true,
+        },
+      ],
+      "/tmp/project",
+    );
+
+    expect(mergeVariables).toHaveBeenCalledWith(
+      { big_number_id: "333333333333333333" },
+      "default",
+    );
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so response display and
+ * runtime variables stay exact. Fixes VoidenHQ/voiden#395 and #408.
+ */
+export function parseJsonPreserveIntegers(text: string): unknown {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const asNumber = Number(digits);
+      return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.parse(normalized);
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString('utf-8'));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -311,7 +312,8 @@ async function parseBody(response: Response): Promise<Buffer | string | object |
   // JSON
   if (contentType.includes("json")) {
     try {
-      return await response.json();
+      const text = await response.text();
+      return parseJsonPreserveIntegers(text);
     } catch (e) {
       return await response.text(); // fallback if parsing fails
     }
@@ -332,7 +334,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString("utf-8"));
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +821,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +66,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +79,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -156,7 +156,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonPreserveIntegers(value);
                 } catch {
                     current=value;
                 }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,7 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 
 /**
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -46,10 +46,22 @@ export interface ResponseBodyAttrs {
 
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+const prettifyJsonText = (text: string): string => {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+};
+
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary

- Add `parseJsonPreserveIntegers` to keep integers beyond `Number.MAX_SAFE_INTEGER` as exact decimal strings during JSON parsing
- Apply the parser across all response body parsing paths (`requestState`, `sendRequestHybrid`, `HybridPipelineExecutor`) and runtime variable extraction
- Fix response body prettify so large IDs are not rounded when formatting JSON for display
- Add regression tests covering issue #408 nested response arrays and runtime variable capture

## Test plan

- [x] `parseJsonPreserveIntegers` unit tests pass (safe integers, unsafe integers, string IDs, nested arrays)
- [x] Runtime variable capture test verifies `{{$res.body.response[0].big_number_id}}` stores `333333333333333333` exactly
- [ ] Execute a request returning a 64-bit snowflake ID and confirm the response viewer shows the exact value
- [ ] Capture the ID into a runtime variable and reuse it in a follow-up request

Closes #408


Made with [Cursor](https://cursor.com)