### PR TITLE
fix(ui): keep file-link Add new file visible in multi-section requests

### DIFF
--- a/apps/ui/src/core/editors/voiden/__test__/fileLinkPopper.test.ts
+++ b/apps/ui/src/core/editors/voiden/__test__/fileLinkPopper.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  computeFileLinkPopperMaxHeight,
+  FILE_LINK_POPPER_PADDING,
+  scrollSelectedItemIntoView,
+} from "@/core/editors/voiden/extensions/fileLinkPopper";
+
+describe("computeFileLinkPopperMaxHeight", () => {
+  it("limits height for bottom placement near the viewport bottom", () => {
+    const maxH = computeFileLinkPopperMaxHeight("bottom-start", 700, 20, 800);
+    expect(maxH).toBe(800 - 700 - 20 - FILE_LINK_POPPER_PADDING);
+  });
+
+  it("limits height for right-start placement when cursor is in a lower section", () => {
+    const maxH = computeFileLinkPopperMaxHeight("right-start", 650, 20, 800);
+    expect(maxH).toBe(800 - 650 - FILE_LINK_POPPER_PADDING);
+  });
+
+  it("limits height for top placement", () => {
+    const maxH = computeFileLinkPopperMaxHeight("top-start", 200, 20, 800);
+    expect(maxH).toBe(200 - FILE_LINK_POPPER_PADDING);
+  });
+
+  it("returns undefined when no vertical room remains", () => {
+    expect(computeFileLinkPopperMaxHeight("right-start", 795, 20, 800)).toBeUndefined();
+  });
+});
+
+describe("scrollSelectedItemIntoView", () => {
+  it("scrolls down when the selected item extends below the container", () => {
+    const container = {
+      scrollTop: 0,
+      getBoundingClientRect: () => ({ top: 100, bottom: 200 }),
+    } as unknown as HTMLElement;
+
+    const item = {
+      getBoundingClientRect: () => ({ top: 150, bottom: 220 }),
+    } as unknown as HTMLElement;
+
+    scrollSelectedItemIntoView(container, item);
+    expect(container.scrollTop).toBe(20);
+  });
+
+  it("scrolls up when the selected item is above the container", () => {
+    const container = {
+      scrollTop: 50,
+      getBoundingClientRect: () => ({ top: 100, bottom: 200 }),
+    } as unknown as HTMLElement;
+
+    const item = {
+      getBoundingClientRect: () => ({ top: 80, bottom: 120 }),
+    } as unknown as HTMLElement;
+
+    scrollSelectedItemIntoView(container, item);
+    expect(container.scrollTop).toBe(30);
+  });
+
+  it("does not scroll when the item is already fully visible", () => {
+    const container = {
+      scrollTop: 10,
+      getBoundingClientRect: vi.fn(() => ({ top: 100, bottom: 200 })),
+    } as unknown as HTMLElement;
+
+    const item = {
+      getBoundingClientRect: vi.fn(() => ({ top: 120, bottom: 180 })),
+    } as unknown as HTMLElement;
+
+    scrollSelectedItemIntoView(container, item);
+    expect(container.scrollTop).toBe(10);
+  });
+});

--- a/apps/ui/src/core/editors/voiden/extensions/ExternalFile.tsx
+++ b/apps/ui/src/core/editors/voiden/extensions/ExternalFile.tsx
@@ -20,6 +20,10 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { useElectronEvent } from "@/core/providers";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getLinkableNodeTypes, getNodeDisplayName } from "@/plugins";
+import {
+  fileLinkConstrainHeightModifierFn,
+  scrollSelectedItemIntoView,
+} from "./fileLinkPopper";
 
 /**
  * TYPES & INTERFACES
@@ -645,30 +649,12 @@ const FileLinkTippyContent = forwardRef((props: FileLinkListProps & { editor?: E
     },
   }));
 
-  // FIXED: Improved smooth scroll behavior with padding
   useEffect(() => {
     const activeItem = itemRefs.current.get(listSelectedIndex);
     const container = isBlockMode ? blockScrollContainer.current : scrollContainer.current;
 
     if (activeItem && container) {
-      const padding = 32; // Extra padding to ensure item is fully visible
-      const itemTop = activeItem.offsetTop;
-      const itemBottom = itemTop + activeItem.offsetHeight;
-      const containerScrollTop = container.scrollTop;
-      const containerHeight = container.clientHeight;
-
-      // Item is below visible area - scroll down
-      if (itemBottom + padding > containerScrollTop + containerHeight) {
-        container.scrollTo({
-          top: itemBottom + padding - containerHeight,
-        });
-      }
-      // Item is above visible area - scroll up
-      else if (itemTop - padding < containerScrollTop) {
-        container.scrollTo({
-          top: itemTop - padding,
-        });
-      }
+      scrollSelectedItemIntoView(container, activeItem);
     }
   }, [listSelectedIndex, isBlockMode]);
 
@@ -909,12 +895,13 @@ const FileLinkTippyContent = forwardRef((props: FileLinkListProps & { editor?: E
   // RENDERING: File mode (default)
   return (
     <div
-      className="w-[480px] bg-panel border border-border rounded-lg shadow-lg text-text text-sm"
+      className="w-[480px] bg-panel border border-border rounded-lg shadow-lg text-text text-sm flex flex-col overflow-hidden"
+      style={{ maxHeight: "var(--popper-max-height, min(80vh, 520px))" }}
       onMouseDown={(e) => e.preventDefault()}
       onClick={() => parentEditor?.view.focus()}
     >
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-bg flex-shrink-0">
         <Folder className="text-accent" size={16} />
         <span className="font-medium text-text">Link File or Block</span>
       </div>
@@ -922,7 +909,7 @@ const FileLinkTippyContent = forwardRef((props: FileLinkListProps & { editor?: E
       {/* File List */}
       <div
         ref={scrollContainer}
-        className="max-h-[400px] overflow-y-auto"
+        className="flex-1 min-h-0 overflow-y-auto"
       >
         {filteredItems.length > 0 ? (
           filteredItems.slice(0, 50).map((item: JSONContent | FileLinkItem, index: number) => {
@@ -1018,12 +1005,13 @@ const FileLinkTippyContent = forwardRef((props: FileLinkListProps & { editor?: E
             Searching deeper…
           </div>
         )}
-        {/* Add new file — always pinned at the bottom */}
-        {addNewButton}
       </div>
 
+      {/* Add new file — pinned outside the scroll area so it stays visible */}
+      {addNewButton}
+
       {/* Footer */}
-      <div className="px-3 py-2 text-xs bg-bg border-t border-border flex justify-between items-center">
+      <div className="px-3 py-2 text-xs bg-bg border-t border-border flex justify-between items-center flex-shrink-0">
         <span className="text-comment">↵ link file • → or Space see blocks</span>
         <span className="text-comment">Shift+↵ multi-select</span>
       </div>
@@ -1433,12 +1421,26 @@ export const FileLink = Node.create<FileLinkOptions>({
                 trigger: "manual",
                 placement: "right-start",
                 popperOptions: {
+                  strategy: "fixed",
                   modifiers: [
                     {
                       name: "flip",
                       options: {
-                        fallbackPlacements: ["left-start", "right-start", "bottom-start", "top-start"],
+                        fallbackPlacements: ["left-start", "bottom-start", "top-start", "right-start"],
                       },
+                    },
+                    {
+                      name: "preventOverflow",
+                      options: {
+                        padding: 8,
+                        altAxis: true,
+                      },
+                    },
+                    {
+                      name: "fileLinkConstrainHeight",
+                      enabled: true,
+                      phase: "beforeWrite",
+                      fn: fileLinkConstrainHeightModifierFn,
                     },
                   ],
                 },

--- a/apps/ui/src/core/editors/voiden/extensions/fileLinkPopper.ts
+++ b/apps/ui/src/core/editors/voiden/extensions/fileLinkPopper.ts
@@ -1,0 +1,70 @@
+/** Viewport padding used by the file-link suggestion popper. */
+export const FILE_LINK_POPPER_PADDING = 8;
+
+/**
+ * Compute max popper height so the menu (including the pinned "Add new file"
+ * button) stays within the viewport for the active placement.
+ */
+export function computeFileLinkPopperMaxHeight(
+  placement: string,
+  referenceTop: number,
+  referenceHeight: number,
+  viewportHeight: number,
+  padding = FILE_LINK_POPPER_PADDING,
+): number | undefined {
+  const side = placement.split("-")[0];
+  if (side === "bottom") {
+    const maxH = viewportHeight - referenceTop - referenceHeight - padding;
+    return maxH > 0 ? maxH : undefined;
+  }
+  if (side === "top") {
+    const maxH = referenceTop - padding;
+    return maxH > 0 ? maxH : undefined;
+  }
+  // right / left: popper top aligns with reference top
+  if (side === "right" || side === "left") {
+    const maxH = viewportHeight - referenceTop - padding;
+    return maxH > 0 ? maxH : undefined;
+  }
+  return undefined;
+}
+
+/** Popper modifier: constrain popper height to available viewport space. */
+export function fileLinkConstrainHeightModifierFn({
+  state,
+}: {
+  state: {
+    placement: string;
+    rects: { reference: { y: number; height: number } };
+    elements: { popper: HTMLElement };
+  };
+}) {
+  const maxH = computeFileLinkPopperMaxHeight(
+    state.placement,
+    state.rects.reference.y,
+    state.rects.reference.height,
+    window.innerHeight,
+  );
+  if (maxH !== undefined) {
+    state.elements.popper.style.maxHeight = `${maxH}px`;
+    state.elements.popper.style.setProperty("--popper-max-height", `${maxH}px`);
+  }
+}
+
+/**
+ * Scroll a list container so the selected item stays visible.
+ * Uses getBoundingClientRect so nested editor scroll offsets are handled.
+ */
+export function scrollSelectedItemIntoView(
+  container: HTMLElement,
+  item: HTMLElement,
+): void {
+  const itemRect = item.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+
+  if (itemRect.bottom > containerRect.bottom) {
+    container.scrollTop += itemRect.bottom - containerRect.bottom;
+  } else if (itemRect.top < containerRect.top) {
+    container.scrollTop -= containerRect.top - itemRect.top;
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the `@` file-link suggestion popper clipping below the viewport when attaching files in a second (or later) request section after pasting multiple cURL commands
- Pins the **Add new file** action outside the scrollable file list so it stays reachable without manually adding blank lines below the section
- Constrains popper height to available viewport space and improves keyboard-navigation scrolling using bounding-rect math

## Root cause
With two or more request sections, the cursor sits lower on the page. The file-link tippy menu used a fixed `max-h-[400px]` scroll region with **Add new file** inside it, and the popper itself was not height-limited — so the bottom of the menu (including the add-file action) could render off-screen.

## Test plan
- [x] `vitest` — `fileLinkPopper.test.ts` (viewport height + scroll helpers)
- [ ] Open a `.void` file with two request sections (paste two cURL commands via "Add as new request")
- [ ] In the second section, add a multipart form row and type `@` in the value cell
- [ ] Confirm **Add new file** is visible without pressing Enter to add spacer paragraphs
- [ ] Keyboard-navigate the file list and confirm the selection stays scrolled into view

Closes #384