### PR TITLE
fix(graphql): resolve variables from active query in multi-request files

### DIFF
--- a/apps/ui/src/core/request-engine/hooks/useSendRequest.ts
+++ b/apps/ui/src/core/request-engine/hooks/useSendRequest.ts
@@ -18,6 +18,34 @@ import { toast } from "@/core/components/ui/sonner";
 import { useVoidenEditorStore } from "@/core/editors/voiden/VoidenEditor";
 import { expandLinkedFilesInDoc } from "@/core/editors/voiden/utils/expandLinkedBlocks";
 
+function getGqlQueryIndexAtPosInSection(
+  editor: Editor,
+  pos: number,
+  sectionIndex: number,
+): number | undefined {
+  let section = 0;
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  editor.state.doc.forEach((child, offset) => {
+    if (child.type.name === "request-separator") {
+      section++;
+      return;
+    }
+    if (section !== sectionIndex) return;
+    if (child.type.name !== "gqlquery") return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
 export const useSendRestRequest = (_editor: Editor) => {
   // Always use the main VoidenEditor, not the passed editor.
   // This is critical for imported/linked blocks whose editor prop
@@ -28,6 +56,7 @@ export const useSendRestRequest = (_editor: Editor) => {
   const activeEnv = useActiveEnvironment();
   const abortControllerRef = useRef<AbortController | null>(null);
   const sectionIndexOverrideRef = useRef<number | undefined>(undefined);
+  const gqlQueryIndexOverrideRef = useRef<number | undefined>(undefined);
   const queryClient = useQueryClient();
 
   /** Open the response panel and activate the response tab. */
@@ -95,9 +124,11 @@ export const useSendRestRequest = (_editor: Editor) => {
         // use it directly. Otherwise detect from DOM or ProseMirror selection.
         let sectionIndex: number | undefined = sectionIndexOverrideRef.current;
         sectionIndexOverrideRef.current = undefined; // Clear after reading
+        let gqlQueryIndex: number | undefined = gqlQueryIndexOverrideRef.current;
+        gqlQueryIndexOverrideRef.current = undefined;
 
+        const nodePos = editor.state.selection.$from.pos;
         if (sectionIndex === undefined) {
-          const nodePos = editor.state.selection.$from.pos;
           sectionIndex = 0;
           editor.state.doc.forEach((child: any, offset: number) => {
             if (child.type.name === "request-separator" && offset < nodePos) {
@@ -105,14 +136,14 @@ export const useSendRestRequest = (_editor: Editor) => {
             }
           });
         }
-        // Fallback to ProseMirror selection
-        const cursorPos = sectionIndex !== undefined ? undefined : editor.state.selection.$from.pos;
-        console.log('[useSendRequest] sectionIndex:', sectionIndex, 'cursorPos:', cursorPos);
+        if (gqlQueryIndex === undefined) {
+          gqlQueryIndex = getGqlQueryIndexAtPosInSection(editor, nodePos, sectionIndex);
+        }
         const response = await requestOrchestrator.executeRequest(
           editor,
           activeEnv,
           abortControllerRef.current.signal,
-          sectionIndex !== undefined ? { sectionIndex } : { sectionPos: cursorPos }
+          { sectionIndex, gqlQueryIndex }
         );
 
         // sendRequestHybrid returns error responses instead of throwing.
@@ -282,6 +313,9 @@ export const useSendRestRequest = (_editor: Editor) => {
             sibling = sibling.nextElementSibling;
           }
           sectionIndexOverrideRef.current = idx;
+
+          const domPos = editor.view.posAtDOM(element, 0);
+          gqlQueryIndexOverrideRef.current = getGqlQueryIndexAtPosInSection(editor, domPos, idx);
         }
       } catch {
         // Ignore — section detection will fall back to cursor/DOM-based approach

--- a/apps/ui/src/core/request-engine/requestOrchestrator.ts
+++ b/apps/ui/src/core/request-engine/requestOrchestrator.ts
@@ -43,6 +43,8 @@ export interface RequestExecuteOptions {
   sectionPos?: number;
   /** Direct section index (0-based), used when DOM-based detection is available */
   sectionIndex?: number;
+  /** 0-based index of the active gqlquery when multiple queries share a section */
+  gqlQueryIndex?: number;
 }
 
 class RequestOrchestratorImpl implements RequestOrchestrator {
@@ -76,6 +78,7 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
     requestLogger.info(`Building request through ${this.requestHandlers.length} plugin handler(s)`);
     let request: any = {
       __sectionPos: options?.sectionPos,
+      __gqlQueryIndex: options?.gqlQueryIndex,
     };
 
     // For multi-request documents, create a scoped editor proxy so all handlers
@@ -195,9 +198,14 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
     for (const handler of this.requestHandlers) {
       try {
         request = await handler(request, handlerEditor);
-        // Preserve __sectionPos across handler chain
-        if (sectionPos !== undefined && request) {
-          request.__sectionPos = sectionPos;
+        // Preserve section context across handler chain
+        if (request) {
+          if (sectionPos !== undefined) {
+            request.__sectionPos = sectionPos;
+          }
+          if (options?.gqlQueryIndex !== undefined) {
+            request.__gqlQueryIndex = options.gqlQueryIndex;
+          }
         }
       } catch (error) {
         requestLogger.error("Error in plugin request handler:", error);

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGraphQLBlocks } from './graphqlBlocks';
+
+describe('resolveGraphQLBlocks', () => {
+  it('pairs variables with the last gqlquery in a multi-request document', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"a":1}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q3');
+    expect(variablesNode?.attrs?.body).toBe('{"c":3}');
+  });
+
+  it('pairs variables with a specific gqlquery when activeQueryIndex is set', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"a":1}' } },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content, 1);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+
+  it('finds variables before the query when listed above it', () => {
+    const content = [
+      { type: 'gqlvariables', attrs: { body: '{"x":9}' } },
+      { type: 'gqlquery', attrs: { uid: 'only' } },
+    ];
+    const { variablesNode } = resolveGraphQLBlocks(content);
+    expect(variablesNode?.attrs?.body).toBe('{"x":9}');
+  });
+
+  it('pairs variables with the middle gqlquery when scoped to that section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+
+  it('does not pair variables from a different query section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"first":true}' } },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"second":true}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"second":true}');
+  });
+
+  it('pairs the first query in a section when activeQueryIndex is 0', () => {
+    const sectionContent = [
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(sectionContent, 0);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+});

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
@@ -1,0 +1,172 @@
+export interface GraphQLContentNode {
+  type?: string;
+  text?: string;
+  attrs?: { body?: string; [key: string]: unknown };
+  content?: GraphQLContentNode[];
+}
+
+export interface GraphQLBlockPair {
+  queryNode: GraphQLContentNode | undefined;
+  variablesNode: GraphQLContentNode | undefined;
+  /** 0-based index among gqlvariables blocks in content */
+  variablesOrdinal?: number;
+}
+
+type ProseMirrorDoc = {
+  forEach: (
+    fn: (child: { type: { name: string }; nodeSize: number }, offset: number) => void,
+  ) => void;
+};
+
+/**
+ * Pair gqlvariables with a specific gqlquery in the active request context.
+ *
+ * When activeQueryIndex is provided, selects that gqlquery (0-based among all
+ * gqlquery blocks in content). Otherwise uses the last gqlquery — the typical
+ * target when multiple queries share a section without separators.
+ */
+export function resolveGraphQLBlocks(
+  content: GraphQLContentNode[] | undefined,
+  activeQueryIndex?: number,
+): GraphQLBlockPair {
+  if (!content?.length) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  const queryIndices: number[] = [];
+  content.forEach((node, index) => {
+    if (node.type === 'gqlquery') {
+      queryIndices.push(index);
+    }
+  });
+
+  if (queryIndices.length === 0) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  let contentIndex: number;
+  if (
+    activeQueryIndex !== undefined &&
+    activeQueryIndex >= 0 &&
+    activeQueryIndex < queryIndices.length
+  ) {
+    contentIndex = queryIndices[activeQueryIndex];
+  } else {
+    contentIndex = queryIndices[queryIndices.length - 1];
+  }
+
+  const queryNode = content[contentIndex];
+  let variablesNode: GraphQLContentNode | undefined;
+
+  for (let i = contentIndex + 1; i < content.length; i++) {
+    if (content[i].type === 'gqlquery') break;
+    if (content[i].type === 'gqlvariables') {
+      variablesNode = content[i];
+      break;
+    }
+  }
+
+  if (!variablesNode) {
+    for (let i = contentIndex - 1; i >= 0; i--) {
+      if (content[i].type === 'gqlquery') break;
+      if (content[i].type === 'gqlvariables') {
+        variablesNode = content[i];
+        break;
+      }
+    }
+  }
+
+  let variablesOrdinal: number | undefined;
+  if (variablesNode) {
+    let ordinal = 0;
+    for (const node of content) {
+      if (node.type === 'gqlvariables') {
+        if (node === variablesNode) {
+          variablesOrdinal = ordinal;
+          break;
+        }
+        ordinal++;
+      }
+    }
+  }
+
+  return { queryNode, variablesNode, variablesOrdinal };
+}
+
+export function getSectionIndexAtPos(doc: ProseMirrorDoc, pos: number): number {
+  let sectionIndex = 0;
+  doc.forEach((child, offset) => {
+    if (child.type.name === 'request-separator' && offset < pos) {
+      sectionIndex++;
+    }
+  });
+  return sectionIndex;
+}
+
+/**
+ * Return the 0-based index of the gqlquery block containing doc position `pos`.
+ * Counts all gqlquery blocks in the document (for full-editor JSON).
+ */
+export function getGqlQueryIndexAtPos(doc: ProseMirrorDoc, pos: number): number | undefined {
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  doc.forEach((child, offset) => {
+    if (child.type.name !== 'gqlquery') return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
+/**
+ * Return the 0-based gqlquery index within a specific request section.
+ * Use when the orchestrator scopes editor JSON to a single section.
+ */
+export function getGqlQueryIndexAtPosInSection(
+  doc: ProseMirrorDoc,
+  pos: number,
+  sectionIndex: number,
+): number | undefined {
+  let section = 0;
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  doc.forEach((child, offset) => {
+    if (child.type.name === 'request-separator') {
+      section++;
+      return;
+    }
+    if (section !== sectionIndex) return;
+    if (child.type.name !== 'gqlquery') return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
+export function parseGraphQLVariablesBody(
+  body: string | undefined,
+): Record<string, unknown> {
+  if (!body?.trim()) return {};
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/core-extensions/src/voiden-graphql/nodes/GqlBodyNode.tsx
+++ b/core-extensions/src/voiden-graphql/nodes/GqlBodyNode.tsx
@@ -22,6 +22,7 @@ import {
 } from "../utils/graphql-parser";
 import { extractOperations, parseQuerySelections } from "../utils/query-parser";
 import { generateQuery } from "../utils/query-generator";
+import { getGqlQueryIndexAtPos, resolveGraphQLBlocks } from "../lib/graphqlBlocks";
 
 export const createGqlBodyNode = (NodeViewWrapper: any, CodeEditor: any) => {
   const getDefaultTemplate = (type: string) => {
@@ -676,26 +677,60 @@ export const createGqlBodyNode = (NodeViewWrapper: any, CodeEditor: any) => {
       }
     }, [selectedOperations, operationFieldSelections, fieldArgSelections, operationArgSelections, nestedFieldSelections, schema, activeTab, mode]);
 
+    const getActiveGqlQueryIndex = React.useCallback(() => {
+      if (typeof props.getPos !== 'function') return undefined;
+      const pos = props.getPos();
+      if (typeof pos !== 'number') return undefined;
+      return getGqlQueryIndexAtPos(props.editor.state.doc, pos);
+    }, [props.editor, props.getPos]);
+
     const syncVariables = React.useCallback(() => {
       const firstOperation = availableOperations[0]?.name;
       if (!firstOperation || !props.node.attrs.body) return;
+
+      const editorJson = props.editor.getJSON();
+      const { variablesOrdinal } = resolveGraphQLBlocks(
+        editorJson.content,
+        getActiveGqlQueryIndex(),
+      );
+      if (variablesOrdinal === undefined) return;
+
       const doc = props.editor.state.doc;
       let variablesNodePos: number | null = null;
       let variablesNode: any = null;
+      let ordinal = 0;
       doc.descendants((node: any, pos: number) => {
-        if (node.type.name === 'gqlvariables') { variablesNode = node; variablesNodePos = pos; return false; }
+        if (node.type.name !== 'gqlvariables') return;
+        if (ordinal === variablesOrdinal) {
+          variablesNode = node;
+          variablesNodePos = pos;
+          return false;
+        }
+        ordinal++;
       });
+
       if (variablesNode && variablesNodePos !== null) {
         const selectedArgs = operationArgSelections[firstOperation] || new Set();
         const currentVariables = variablesNode.attrs.body;
-        const newVariables = generateVariablesFromQuery(props.node.attrs.body, currentVariables, firstOperation, selectedArgs);
+        const newVariables = generateVariablesFromQuery(
+          props.node.attrs.body,
+          currentVariables,
+          firstOperation,
+          selectedArgs,
+        );
         if (newVariables !== currentVariables) {
           const tr = props.editor.state.tr;
           tr.setNodeMarkup(variablesNodePos, null, { ...variablesNode.attrs, body: newVariables });
           props.editor.view.dispatch(tr);
         }
       }
-    }, [props.node.attrs.body, availableOperations, operationArgSelections, props.editor]);
+    }, [
+      props.node.attrs.body,
+      availableOperations,
+      operationArgSelections,
+      props.editor,
+      getActiveGqlQueryIndex,
+    ]);
 
     React.useEffect(() => { syncVariables(); }, [syncVariables]);
 

--- a/core-extensions/src/voiden-graphql/plugin.ts
+++ b/core-extensions/src/voiden-graphql/plugin.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PluginContext } from '@voiden/sdk/ui';
+import { parseGraphQLVariablesBody, resolveGraphQLBlocks } from './lib/graphqlBlocks';
 import { parseGraphQLOperation } from './lib/utils';
 import manifest from './manifest.json';
 
@@ -76,10 +77,12 @@ export default function createGraphQLPlugin(context: PluginContext) {
           // Build request WITHOUT environment variables
           // Environment variables will be replaced securely in Electron (Stage 3)
           // Faker variables will be replaced at Stage 5 (Pre-Send) by the faker extension
+          const activeQueryIndex =
+            typeof request?.__gqlQueryIndex === 'number' ? request.__gqlQueryIndex : undefined;
           request = await getRequest(editorJson, undefined, undefined);
-          // Only handle documents with a gqlquery node
-          const gqlNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlquery'
+          const { queryNode: gqlNode, variablesNode: gqlVariablesNode } = resolveGraphQLBlocks(
+            editorJson.content,
+            activeQueryIndex,
           );
           if (!gqlNode) return request; // Not a GraphQL doc, pass through
 
@@ -98,18 +101,7 @@ export default function createGraphQLPlugin(context: PluginContext) {
             operationName = match[2];
           }
 
-          // Get variables from gqlvariables block
-          const gqlVariablesNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlvariables'
-          );
-          let variables: any = {};
-          if (gqlVariablesNode) {
-            try {
-              variables = JSON.parse(gqlVariablesNode.attrs?.body || '{}');
-            } catch (e) {
-              // ignore parse errors
-            }
-          }
+          const variables = parseGraphQLVariablesBody(gqlVariablesNode?.attrs?.body);
 
           // URL: from gqlurl child text, or legacy attrs.endpoint, or schemaUrl
           const gqlUrlText = gqlUrlChild?.content?.[0]?.text || gqlUrlChild?.content || '';


### PR DESCRIPTION
## Summary

- Adds `resolveGraphQLBlocks()` to pair each `gqlvariables` block with the executing `gqlquery` (nearest forward/backward), instead of always using the first blocks in the document.
- Passes `gqlQueryIndex` through the request orchestrator so play-button and cursor-based sends target the correct query when multiple GraphQL requests share a file.
- Updates `GqlBodyNode` variable auto-sync to update the paired variables block for the active query.

Closes #391

## Test plan

- [x] `yarn vitest run core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts`
- [ ] Manual: create a file with 3 GraphQL requests and distinct variable JSON per request; send the third request and confirm the outgoing payload uses the third request's variables
- [ ] Manual: repeat without `request-separator` nodes between queries and send the middle query via its play button

Made with [Cursor](https://cursor.com)