### PR TITLE
fix: GraphQL variable pairing and JSON integer precision

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -109,6 +109,7 @@
     "immer": "^10.0.3",
     "js-base64": "^3.7.7",
     "js-cookie": "^3.0.5",
+    "lossless-json": "^4.0.2",
     "lucide-react": "^0.474.0",
     "marked": "^14.1.2",
     "next-themes": "^0.3.0",

--- a/apps/ui/src/core/history/pipelineHooks.ts
+++ b/apps/ui/src/core/history/pipelineHooks.ts
@@ -12,6 +12,7 @@ import { useHistoryStore } from './historyStore';
 import { appendToHistory } from './historyManager';
 import { useResponseStore } from '@/core/request-engine/stores/responseStore';
 import { historyAdapterRegistry } from './adapterRegistry';
+import { stringifyJsonLossless } from '@/utils/losslessJson';
 
 /** Cached between pre-processing and post-processing within a single request */
 let cachedFilePath: string | null = null;
@@ -230,7 +231,7 @@ async function buildFallbackEntry(requestState: any, responseState: any, project
     try {
       const raw = typeof responseState.body === 'string'
         ? responseState.body
-        : JSON.stringify(responseState.body, null, 2);
+        : stringifyJsonLossless(responseState.body, 2);
       responseBody = raw.length > 102400 ? raw.slice(0, 102400) + '\n… (truncated)' : raw;
     } catch { /* skip */ }
   }

--- a/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { saveRuntimeVariables } from "../runtimeVariables";
+import { parseJsonLossless } from "@/utils/losslessJson";
+
+describe("runtime variables with large integers", () => {
+  const mergeVariables = vi.fn().mockResolvedValue(undefined);
+  const getActiveEnvKey = vi.fn().mockResolvedValue("default");
+  const updateGitignore = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).window = {
+      electron: {
+        variables: { mergeVariables, getActiveEnvKey },
+        git: { updateGitignore },
+      },
+    };
+  });
+
+  it("captures large response IDs without rounding (#408)", async () => {
+    const rawBody = '{"response":[{"big_number_id":333333333333333333}]}';
+    const resObject = {
+      body: parseJsonLossless(rawBody),
+    };
+
+    await saveRuntimeVariables(
+      undefined,
+      resObject,
+      [
+        {
+          key: "big_number_id",
+          value: "{{$res.body.response[0].big_number_id}}",
+          enabled: true,
+        },
+      ],
+      "/tmp/project",
+    );
+
+    expect(mergeVariables).toHaveBeenCalledWith(
+      { big_number_id: 333333333333333333n },
+      "default",
+    );
+  });
+});

--- a/apps/ui/src/core/request-engine/hooks/useSendRequest.ts
+++ b/apps/ui/src/core/request-engine/hooks/useSendRequest.ts
@@ -18,6 +18,34 @@ import { toast } from "@/core/components/ui/sonner";
 import { useVoidenEditorStore } from "@/core/editors/voiden/VoidenEditor";
 import { expandLinkedFilesInDoc } from "@/core/editors/voiden/utils/expandLinkedBlocks";
 
+function getGqlQueryIndexAtPosInSection(
+  editor: Editor,
+  pos: number,
+  sectionIndex: number,
+): number | undefined {
+  let section = 0;
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  editor.state.doc.forEach((child, offset) => {
+    if (child.type.name === "request-separator") {
+      section++;
+      return;
+    }
+    if (section !== sectionIndex) return;
+    if (child.type.name !== "gqlquery") return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
 export const useSendRestRequest = (_editor: Editor) => {
   // Always use the main VoidenEditor, not the passed editor.
   // This is critical for imported/linked blocks whose editor prop
@@ -28,6 +56,7 @@ export const useSendRestRequest = (_editor: Editor) => {
   const activeEnv = useActiveEnvironment();
   const abortControllerRef = useRef<AbortController | null>(null);
   const sectionIndexOverrideRef = useRef<number | undefined>(undefined);
+  const gqlQueryIndexOverrideRef = useRef<number | undefined>(undefined);
   const queryClient = useQueryClient();
 
   /** Open the response panel and activate the response tab. */
@@ -95,9 +124,11 @@ export const useSendRestRequest = (_editor: Editor) => {
         // use it directly. Otherwise detect from DOM or ProseMirror selection.
         let sectionIndex: number | undefined = sectionIndexOverrideRef.current;
         sectionIndexOverrideRef.current = undefined; // Clear after reading
+        let gqlQueryIndex: number | undefined = gqlQueryIndexOverrideRef.current;
+        gqlQueryIndexOverrideRef.current = undefined;
 
+        const nodePos = editor.state.selection.$from.pos;
         if (sectionIndex === undefined) {
-          const nodePos = editor.state.selection.$from.pos;
           sectionIndex = 0;
           editor.state.doc.forEach((child: any, offset: number) => {
             if (child.type.name === "request-separator" && offset < nodePos) {
@@ -105,14 +136,14 @@ export const useSendRestRequest = (_editor: Editor) => {
             }
           });
         }
-        // Fallback to ProseMirror selection
-        const cursorPos = sectionIndex !== undefined ? undefined : editor.state.selection.$from.pos;
-        console.log('[useSendRequest] sectionIndex:', sectionIndex, 'cursorPos:', cursorPos);
+        if (gqlQueryIndex === undefined) {
+          gqlQueryIndex = getGqlQueryIndexAtPosInSection(editor, nodePos, sectionIndex);
+        }
         const response = await requestOrchestrator.executeRequest(
           editor,
           activeEnv,
           abortControllerRef.current.signal,
-          sectionIndex !== undefined ? { sectionIndex } : { sectionPos: cursorPos }
+          { sectionIndex, gqlQueryIndex }
         );
 
         // sendRequestHybrid returns error responses instead of throwing.
@@ -282,6 +313,9 @@ export const useSendRestRequest = (_editor: Editor) => {
             sibling = sibling.nextElementSibling;
           }
           sectionIndexOverrideRef.current = idx;
+
+          const domPos = editor.view.posAtDOM(element, 0);
+          gqlQueryIndexOverrideRef.current = getGqlQueryIndexAtPosInSection(editor, domPos, idx);
         }
       } catch {
         // Ignore — section detection will fall back to cursor/DOM-based approach

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -9,6 +9,7 @@
  */
 
 import { Editor } from '@tiptap/core';
+import { parseJsonLossless, stringifyJsonLossless } from '@/utils/losslessJson';
 import {
   PipelineStage,
   RestApiRequestState,
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString());
         } catch {
           body = buffer.toString();
         }
@@ -233,7 +234,7 @@ export class HybridPipelineExecutor {
     }
 
     // Calculate size
-    const bodyString = typeof body === 'string' ? body : JSON.stringify(body);
+    const bodyString = typeof body === 'string' ? body : stringifyJsonLossless(body);
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     return {

--- a/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
@@ -18,6 +18,7 @@ import {
 } from './types';
 import { hookRegistry } from './HookRegistry';
 import type { Environment } from '../requestState';
+import { parseJsonLossless, stringifyJsonLossless } from '@/utils/losslessJson';
 
 /**
  * Main pipeline executor class
@@ -293,7 +294,7 @@ export class PipelineExecutor {
 
     try {
       if (contentType?.includes('json')) {
-        body = await response.json();
+        body = parseJsonLossless(await response.text());
       } else if (contentType?.includes('text')) {
         body = await response.text();
       } else {
@@ -312,7 +313,7 @@ export class PipelineExecutor {
     }));
 
     // Calculate size
-    const bodyString = typeof body === 'string' ? body : JSON.stringify(body);
+    const bodyString = typeof body === 'string' ? body : stringifyJsonLossless(body);
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     const responseState: RestApiResponseState = {

--- a/apps/ui/src/core/request-engine/pipeline/__test__/pipeline.test.ts
+++ b/apps/ui/src/core/request-engine/pipeline/__test__/pipeline.test.ts
@@ -282,7 +282,7 @@ describe('PipelineExecutor', () => {
       statusText: 'OK',
       headers: new Map([['content-type', 'application/json']]),
       json: async () => ({ success: true }),
-      text: async () => 'success',
+      text: async () => JSON.stringify({ success: true }),
       arrayBuffer: async () => new ArrayBuffer(0),
       url: 'https://api.example.com',
     });

--- a/apps/ui/src/core/request-engine/requestOrchestrator.ts
+++ b/apps/ui/src/core/request-engine/requestOrchestrator.ts
@@ -43,6 +43,8 @@ export interface RequestExecuteOptions {
   sectionPos?: number;
   /** Direct section index (0-based), used when DOM-based detection is available */
   sectionIndex?: number;
+  /** 0-based index of the active gqlquery when multiple queries share a section */
+  gqlQueryIndex?: number;
 }
 
 class RequestOrchestratorImpl implements RequestOrchestrator {
@@ -76,6 +78,7 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
     requestLogger.info(`Building request through ${this.requestHandlers.length} plugin handler(s)`);
     let request: any = {
       __sectionPos: options?.sectionPos,
+      __gqlQueryIndex: options?.gqlQueryIndex,
     };
 
     // For multi-request documents, create a scoped editor proxy so all handlers
@@ -195,9 +198,14 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
     for (const handler of this.requestHandlers) {
       try {
         request = await handler(request, handlerEditor);
-        // Preserve __sectionPos across handler chain
-        if (sectionPos !== undefined && request) {
-          request.__sectionPos = sectionPos;
+        // Preserve section context across handler chain
+        if (request) {
+          if (sectionPos !== undefined) {
+            request.__sectionPos = sectionPos;
+          }
+          if (options?.gqlQueryIndex !== undefined) {
+            request.__gqlQueryIndex = options.gqlQueryIndex;
+          }
         }
       } catch (error) {
         requestLogger.error("Error in plugin request handler:", error);

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonLossless } from "@/utils/losslessJson";
 
 export interface EnvironmentVariable {
   key: string;
@@ -311,7 +312,7 @@ async function parseBody(response: Response): Promise<Buffer | string | object |
   // JSON
   if (contentType.includes("json")) {
     try {
-      return await response.json();
+      return parseJsonLossless(await response.text());
     } catch (e) {
       return await response.text(); // fallback if parsing fails
     }
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonLossless(bytes.toString());
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,9 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import {
+    losslessValueToString,
+    parseJsonLossless,
+    stringifyJsonLossless,
+} from "@/utils/losslessJson";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +70,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonLossless(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +83,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonLossless(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -156,7 +160,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonLossless(value);
                 } catch {
                     current=value;
                 }
@@ -275,8 +279,8 @@ function replaceTemplateExpressions(
         if (extractedValue !== undefined && extractedValue !== null) {
             // Convert to string for replacement
             const stringValue = typeof extractedValue === 'object'
-                ? JSON.stringify(extractedValue)
-                : String(extractedValue);
+                ? stringifyJsonLossless(extractedValue)
+                : losslessValueToString(extractedValue);
 
             result = result.replace(expression, stringValue);
         } else {

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,7 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parseJsonLossless, stringifyJsonLossless } from "@/utils/losslessJson";
 
 
 /**
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonLossless(buffer.toString());
         } catch {
           body = buffer.toString();
         }
@@ -426,7 +427,7 @@ export async function sendRequestHybrid(
     }
 
     // Calculate size
-    const bodyString = typeof body === "string" ? body : JSON.stringify(body);
+    const bodyString = typeof body === "string" ? body : stringifyJsonLossless(body);
     const bytesContent = new TextEncoder().encode(bodyString).length;
 
     const endTime = performance.now();

--- a/apps/ui/src/utils/__test__/losslessJson.test.ts
+++ b/apps/ui/src/utils/__test__/losslessJson.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  losslessValueToString,
+  parseJsonLossless,
+  prettifyJsonLossless,
+  stringifyJsonLossless,
+} from "../losslessJson";
+
+const LARGE_ID = 174322306148984899n;
+const ROUNDED_ID = 174322306148984900;
+
+describe("losslessJson", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER (issue #395)", () => {
+    const parsed = parseJsonLossless(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: bigint } };
+
+    expect(parsed.args.id).toBe(LARGE_ID);
+    expect(parsed.args.id).not.toBe(BigInt(ROUNDED_ID));
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonLossless('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+    expect(typeof parsed.count).toBe("number");
+  });
+
+  it("stringifies bigint values without rounding", () => {
+    const text = stringifyJsonLossless({ args: { id: LARGE_ID } }, 2);
+    expect(text).toContain("174322306148984899");
+    expect(text).not.toContain(String(ROUNDED_ID));
+  });
+
+  it("prettify round-trip preserves large integers", () => {
+    const raw = '{"args":{"id":174322306148984899}}';
+    const pretty = prettifyJsonLossless(raw);
+    expect(pretty).toContain("174322306148984899");
+    expect(pretty).not.toContain(String(ROUNDED_ID));
+  });
+
+  it("losslessValueToString returns exact digits for bigint", () => {
+    expect(losslessValueToString(LARGE_ID)).toBe("174322306148984899");
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonLossless('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+
+  it("preserves 18-digit snowflake IDs from issue #408", () => {
+    const parsed = parseJsonLossless(
+      '{"response":[{"big_number_id":333333333333333333}]}',
+    ) as { response: Array<{ big_number_id: bigint }> };
+
+    expect(parsed.response[0].big_number_id).toBe(333333333333333333n);
+    expect(parsed.response[0].big_number_id).not.toBe(333333333333333300n);
+  });
+
+  it("keeps string-serialized large IDs exact for runtime variables (#408)", () => {
+    const parsed = parseJsonLossless(
+      '{"big_number_id":"333333333333333333"}',
+    ) as { big_number_id: string };
+
+    expect(parsed.big_number_id).toBe("333333333333333333");
+    expect(losslessValueToString(parsed.big_number_id)).toBe("333333333333333333");
+  });
+
+  it("end-to-end: parse, extract nested path, and stringify for display (#395)", () => {
+    const responseText = '{"args":{"id":174322306148984899}}';
+    const parsed = parseJsonLossless(responseText) as {
+      args: { id: bigint };
+    };
+
+    const extractedId = parsed.args.id;
+    expect(losslessValueToString(extractedId)).toBe("174322306148984899");
+    expect(losslessValueToString(extractedId)).not.toBe(String(ROUNDED_ID));
+
+    const historySnapshot = stringifyJsonLossless(parsed, 2);
+    expect(historySnapshot).toContain("174322306148984899");
+    expect(historySnapshot).not.toContain(String(ROUNDED_ID));
+  });
+});

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -2,14 +2,10 @@ import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
+import { prettifyJsonLossless } from "./losslessJson";
 
 export function prettifyJSON(json: string) {
-  try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
-  } catch (error) {
-    return json;
-  }
+  return prettifyJsonLossless(json);
 }
 
 export const getFileIfNotExist = async (docId: string, fileId: string, fileName: string): Promise<File | null> => {

--- a/apps/ui/src/utils/losslessJson.ts
+++ b/apps/ui/src/utils/losslessJson.ts
@@ -1,0 +1,50 @@
+import {
+  isInteger,
+  isLosslessNumber,
+  isSafeNumber,
+  parse,
+  stringify,
+} from "lossless-json";
+
+/**
+ * Parse a JSON numeric token without losing precision for integers outside
+ * Number.MAX_SAFE_INTEGER. Safe integers remain numbers; larger integers become bigint.
+ */
+export function parseNumberSafe(value: string): number | bigint {
+  if (isInteger(value) && isSafeNumber(value)) {
+    return Number(value);
+  }
+  if (isInteger(value)) {
+    return BigInt(value);
+  }
+  return Number(value);
+}
+
+/** Parse JSON text while preserving large integer precision. */
+export function parseJsonLossless(text: string): unknown {
+  return parse(text, undefined, parseNumberSafe);
+}
+
+/** Stringify JSON values, including bigint and LosslessNumber instances. */
+export function stringifyJsonLossless(value: unknown, space?: number | string): string {
+  return stringify(value, null, space) ?? "";
+}
+
+/** Parse and re-format JSON with indentation, preserving large integer precision. */
+export function prettifyJsonLossless(json: string): string {
+  try {
+    return stringifyJsonLossless(parseJsonLossless(json), 2);
+  } catch {
+    return json;
+  }
+}
+
+/** Convert a parsed JSON value to a string without rounding large integers. */
+export function losslessValueToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isLosslessNumber(value)) return value.toString();
+  return stringifyJsonLossless(value);
+}

--- a/core-extensions/package.json
+++ b/core-extensions/package.json
@@ -54,6 +54,7 @@
     "@faker-js/faker": "^9.0.3",
     "@voiden/sdk": "^1.0.9",
     "js-yaml": "^4.1.0",
+    "lossless-json": "^4.0.2",
     "selfsigned": "^5.5.0",
     "shell-quote": "^1.8.1",
     "xlsx-js-style": "^1.2.0"

--- a/core-extensions/src/utils/losslessJson.ts
+++ b/core-extensions/src/utils/losslessJson.ts
@@ -1,0 +1,42 @@
+import {
+  isInteger,
+  isLosslessNumber,
+  isSafeNumber,
+  parse,
+  stringify,
+} from "lossless-json";
+
+export function parseNumberSafe(value: string): number | bigint {
+  if (isInteger(value) && isSafeNumber(value)) {
+    return Number(value);
+  }
+  if (isInteger(value)) {
+    return BigInt(value);
+  }
+  return Number(value);
+}
+
+export function parseJsonLossless(text: string): unknown {
+  return parse(text, undefined, parseNumberSafe);
+}
+
+export function stringifyJsonLossless(value: unknown, space?: number | string): string {
+  return stringify(value, null, space) ?? "";
+}
+
+export function prettifyJsonLossless(json: string): string {
+  try {
+    return stringifyJsonLossless(parseJsonLossless(json), 2);
+  } catch {
+    return json;
+  }
+}
+
+export function losslessValueToString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (isLosslessNumber(value)) return value.toString();
+  return stringifyJsonLossless(value);
+}

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { resolveGraphQLBlocks } from './graphqlBlocks';
+
+describe('resolveGraphQLBlocks', () => {
+  it('pairs variables with the last gqlquery in a multi-request document', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"a":1}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'request-separator', attrs: {} },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q3');
+    expect(variablesNode?.attrs?.body).toBe('{"c":3}');
+  });
+
+  it('pairs variables with a specific gqlquery when activeQueryIndex is set', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"a":1}' } },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content, 1);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+
+  it('finds variables before the query when listed above it', () => {
+    const content = [
+      { type: 'gqlvariables', attrs: { body: '{"x":9}' } },
+      { type: 'gqlquery', attrs: { uid: 'only' } },
+    ];
+    const { variablesNode } = resolveGraphQLBlocks(content);
+    expect(variablesNode?.attrs?.body).toBe('{"x":9}');
+  });
+
+  it('pairs variables with the middle gqlquery when scoped to that section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+
+  it('does not pair variables from a different query section', () => {
+    const content = [
+      { type: 'gqlquery', attrs: { uid: 'q1' } },
+      { type: 'gqlvariables', attrs: { body: '{"first":true}' } },
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"second":true}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(content);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"second":true}');
+  });
+
+  it('pairs the first query in a section when activeQueryIndex is 0', () => {
+    const sectionContent = [
+      { type: 'gqlquery', attrs: { uid: 'q2' } },
+      { type: 'gqlvariables', attrs: { body: '{"b":2}' } },
+      { type: 'gqlquery', attrs: { uid: 'q3' } },
+      { type: 'gqlvariables', attrs: { body: '{"c":3}' } },
+    ];
+
+    const { queryNode, variablesNode } = resolveGraphQLBlocks(sectionContent, 0);
+    expect(queryNode?.attrs?.uid).toBe('q2');
+    expect(variablesNode?.attrs?.body).toBe('{"b":2}');
+  });
+});

--- a/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
+++ b/core-extensions/src/voiden-graphql/lib/graphqlBlocks.ts
@@ -1,0 +1,172 @@
+export interface GraphQLContentNode {
+  type?: string;
+  text?: string;
+  attrs?: { body?: string; [key: string]: unknown };
+  content?: GraphQLContentNode[];
+}
+
+export interface GraphQLBlockPair {
+  queryNode: GraphQLContentNode | undefined;
+  variablesNode: GraphQLContentNode | undefined;
+  /** 0-based index among gqlvariables blocks in content */
+  variablesOrdinal?: number;
+}
+
+type ProseMirrorDoc = {
+  forEach: (
+    fn: (child: { type: { name: string }; nodeSize: number }, offset: number) => void,
+  ) => void;
+};
+
+/**
+ * Pair gqlvariables with a specific gqlquery in the active request context.
+ *
+ * When activeQueryIndex is provided, selects that gqlquery (0-based among all
+ * gqlquery blocks in content). Otherwise uses the last gqlquery — the typical
+ * target when multiple queries share a section without separators.
+ */
+export function resolveGraphQLBlocks(
+  content: GraphQLContentNode[] | undefined,
+  activeQueryIndex?: number,
+): GraphQLBlockPair {
+  if (!content?.length) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  const queryIndices: number[] = [];
+  content.forEach((node, index) => {
+    if (node.type === 'gqlquery') {
+      queryIndices.push(index);
+    }
+  });
+
+  if (queryIndices.length === 0) {
+    return { queryNode: undefined, variablesNode: undefined };
+  }
+
+  let contentIndex: number;
+  if (
+    activeQueryIndex !== undefined &&
+    activeQueryIndex >= 0 &&
+    activeQueryIndex < queryIndices.length
+  ) {
+    contentIndex = queryIndices[activeQueryIndex];
+  } else {
+    contentIndex = queryIndices[queryIndices.length - 1];
+  }
+
+  const queryNode = content[contentIndex];
+  let variablesNode: GraphQLContentNode | undefined;
+
+  for (let i = contentIndex + 1; i < content.length; i++) {
+    if (content[i].type === 'gqlquery') break;
+    if (content[i].type === 'gqlvariables') {
+      variablesNode = content[i];
+      break;
+    }
+  }
+
+  if (!variablesNode) {
+    for (let i = contentIndex - 1; i >= 0; i--) {
+      if (content[i].type === 'gqlquery') break;
+      if (content[i].type === 'gqlvariables') {
+        variablesNode = content[i];
+        break;
+      }
+    }
+  }
+
+  let variablesOrdinal: number | undefined;
+  if (variablesNode) {
+    let ordinal = 0;
+    for (const node of content) {
+      if (node.type === 'gqlvariables') {
+        if (node === variablesNode) {
+          variablesOrdinal = ordinal;
+          break;
+        }
+        ordinal++;
+      }
+    }
+  }
+
+  return { queryNode, variablesNode, variablesOrdinal };
+}
+
+export function getSectionIndexAtPos(doc: ProseMirrorDoc, pos: number): number {
+  let sectionIndex = 0;
+  doc.forEach((child, offset) => {
+    if (child.type.name === 'request-separator' && offset < pos) {
+      sectionIndex++;
+    }
+  });
+  return sectionIndex;
+}
+
+/**
+ * Return the 0-based index of the gqlquery block containing doc position `pos`.
+ * Counts all gqlquery blocks in the document (for full-editor JSON).
+ */
+export function getGqlQueryIndexAtPos(doc: ProseMirrorDoc, pos: number): number | undefined {
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  doc.forEach((child, offset) => {
+    if (child.type.name !== 'gqlquery') return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
+/**
+ * Return the 0-based gqlquery index within a specific request section.
+ * Use when the orchestrator scopes editor JSON to a single section.
+ */
+export function getGqlQueryIndexAtPosInSection(
+  doc: ProseMirrorDoc,
+  pos: number,
+  sectionIndex: number,
+): number | undefined {
+  let section = 0;
+  let queryIndex = 0;
+  let activeIndex: number | undefined;
+
+  doc.forEach((child, offset) => {
+    if (child.type.name === 'request-separator') {
+      section++;
+      return;
+    }
+    if (section !== sectionIndex) return;
+    if (child.type.name !== 'gqlquery') return;
+
+    const nodeStart = offset + 1;
+    const nodeEnd = nodeStart + child.nodeSize;
+    if (pos >= nodeStart && pos < nodeEnd) {
+      activeIndex = queryIndex;
+    }
+    queryIndex++;
+  });
+
+  return activeIndex;
+}
+
+export function parseGraphQLVariablesBody(
+  body: string | undefined,
+): Record<string, unknown> {
+  if (!body?.trim()) return {};
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/core-extensions/src/voiden-graphql/nodes/GqlBodyNode.tsx
+++ b/core-extensions/src/voiden-graphql/nodes/GqlBodyNode.tsx
@@ -22,6 +22,7 @@ import {
 } from "../utils/graphql-parser";
 import { extractOperations, parseQuerySelections } from "../utils/query-parser";
 import { generateQuery } from "../utils/query-generator";
+import { getGqlQueryIndexAtPos, resolveGraphQLBlocks } from "../lib/graphqlBlocks";
 
 export const createGqlBodyNode = (NodeViewWrapper: any, CodeEditor: any) => {
   const getDefaultTemplate = (type: string) => {
@@ -676,26 +677,60 @@ export const createGqlBodyNode = (NodeViewWrapper: any, CodeEditor: any) => {
       }
     }, [selectedOperations, operationFieldSelections, fieldArgSelections, operationArgSelections, nestedFieldSelections, schema, activeTab, mode]);
 
+    const getActiveGqlQueryIndex = React.useCallback(() => {
+      if (typeof props.getPos !== 'function') return undefined;
+      const pos = props.getPos();
+      if (typeof pos !== 'number') return undefined;
+      return getGqlQueryIndexAtPos(props.editor.state.doc, pos);
+    }, [props.editor, props.getPos]);
+
     const syncVariables = React.useCallback(() => {
       const firstOperation = availableOperations[0]?.name;
       if (!firstOperation || !props.node.attrs.body) return;
+
+      const editorJson = props.editor.getJSON();
+      const { variablesOrdinal } = resolveGraphQLBlocks(
+        editorJson.content,
+        getActiveGqlQueryIndex(),
+      );
+      if (variablesOrdinal === undefined) return;
+
       const doc = props.editor.state.doc;
       let variablesNodePos: number | null = null;
       let variablesNode: any = null;
+      let ordinal = 0;
       doc.descendants((node: any, pos: number) => {
-        if (node.type.name === 'gqlvariables') { variablesNode = node; variablesNodePos = pos; return false; }
+        if (node.type.name !== 'gqlvariables') return;
+        if (ordinal === variablesOrdinal) {
+          variablesNode = node;
+          variablesNodePos = pos;
+          return false;
+        }
+        ordinal++;
       });
+
       if (variablesNode && variablesNodePos !== null) {
         const selectedArgs = operationArgSelections[firstOperation] || new Set();
         const currentVariables = variablesNode.attrs.body;
-        const newVariables = generateVariablesFromQuery(props.node.attrs.body, currentVariables, firstOperation, selectedArgs);
+        const newVariables = generateVariablesFromQuery(
+          props.node.attrs.body,
+          currentVariables,
+          firstOperation,
+          selectedArgs,
+        );
         if (newVariables !== currentVariables) {
           const tr = props.editor.state.tr;
           tr.setNodeMarkup(variablesNodePos, null, { ...variablesNode.attrs, body: newVariables });
           props.editor.view.dispatch(tr);
         }
       }
-    }, [props.node.attrs.body, availableOperations, operationArgSelections, props.editor]);
+    }, [
+      props.node.attrs.body,
+      availableOperations,
+      operationArgSelections,
+      props.editor,
+      getActiveGqlQueryIndex,
+    ]);
 
     React.useEffect(() => { syncVariables(); }, [syncVariables]);
 

--- a/core-extensions/src/voiden-graphql/plugin.ts
+++ b/core-extensions/src/voiden-graphql/plugin.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PluginContext } from '@voiden/sdk/ui';
+import { parseGraphQLVariablesBody, resolveGraphQLBlocks } from './lib/graphqlBlocks';
 import { parseGraphQLOperation } from './lib/utils';
 import manifest from './manifest.json';
 
@@ -76,10 +77,12 @@ export default function createGraphQLPlugin(context: PluginContext) {
           // Build request WITHOUT environment variables
           // Environment variables will be replaced securely in Electron (Stage 3)
           // Faker variables will be replaced at Stage 5 (Pre-Send) by the faker extension
+          const activeQueryIndex =
+            typeof request?.__gqlQueryIndex === 'number' ? request.__gqlQueryIndex : undefined;
           request = await getRequest(editorJson, undefined, undefined);
-          // Only handle documents with a gqlquery node
-          const gqlNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlquery'
+          const { queryNode: gqlNode, variablesNode: gqlVariablesNode } = resolveGraphQLBlocks(
+            editorJson.content,
+            activeQueryIndex,
           );
           if (!gqlNode) return request; // Not a GraphQL doc, pass through
 
@@ -98,18 +101,7 @@ export default function createGraphQLPlugin(context: PluginContext) {
             operationName = match[2];
           }
 
-          // Get variables from gqlvariables block
-          const gqlVariablesNode = editorJson.content?.find(
-            (n: any) => n.type === 'gqlvariables'
-          );
-          let variables: any = {};
-          if (gqlVariablesNode) {
-            try {
-              variables = JSON.parse(gqlVariablesNode.attrs?.body || '{}');
-            } catch (e) {
-              // ignore parse errors
-            }
-          }
+          const variables = parseGraphQLVariablesBody(gqlVariablesNode?.attrs?.body);
 
           // URL: from gqlurl child text, or legacy attrs.endpoint, or schemaUrl
           const gqlUrlText = gqlUrlChild?.content?.[0]?.text || gqlUrlChild?.content || '';

--- a/core-extensions/src/voiden-rest-api/historyAdapter.tsx
+++ b/core-extensions/src/voiden-rest-api/historyAdapter.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useState } from 'react';
+import { stringifyJsonLossless } from '../utils/losslessJson';
 
 // ─── Adapter contract types (mirrors adapterRegistry — defined locally to avoid cross-rootDir import) ──
 
@@ -360,7 +361,7 @@ async function captureEntry(pipelineContext: any): Promise<HistoryPluginEntry & 
     try {
       const raw = typeof responseState.body === 'string'
         ? responseState.body
-        : JSON.stringify(responseState.body, null, 2);
+        : stringifyJsonLossless(responseState.body, 2);
       responseBody = raw.length > 102400 ? raw.slice(0, 102400) + '\n… (truncated)' : raw;
     } catch { /* skip */ }
   }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { AlertCircle, Check, ChevronDown, Copy, Download, Eye, FileDown, FileText, WrapText } from "lucide-react";
+import { prettifyJsonLossless, stringifyJsonLossless } from "../../utils/losslessJson";
 
 type LangOption = { label: string; value: string };
 const LANG_OPTIONS: LangOption[] = [
@@ -49,7 +50,7 @@ const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript",
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonLossless(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);
@@ -167,11 +168,11 @@ export const createResponseBodyNode = (
       }
       let text: string;
       if (isJson) {
-        text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        text = typeof body === "string" ? body : stringifyJsonLossless(body, 2);
       } else if (isXml || isHtml || isText) {
         text = typeof body === "string" ? body : String(body);
       } else if (typeof body === "object") {
-        text = JSON.stringify(body, null, 2);
+        text = stringifyJsonLossless(body, 2);
       } else {
         text = String(body);
       }
@@ -261,7 +262,7 @@ export const createResponseBodyNode = (
           const uint8Array = new Uint8Array(body.data);
           blob = new Blob([uint8Array as any], { type: contentType || "application/octet-stream" });
         } else {
-          blob = new Blob([JSON.stringify(body, null, 2)], { type: "application/json" });
+          blob = new Blob([stringifyJsonLossless(body, 2)], { type: "application/json" });
         }
 
         const url = URL.createObjectURL(blob);
@@ -281,7 +282,7 @@ export const createResponseBodyNode = (
     // Copy handler
     const handleCopy = async () => {
       try {
-        const textToCopy = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        const textToCopy = typeof body === "string" ? body : stringifyJsonLossless(body, 2);
         await navigator.clipboard.writeText(textToCopy);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -615,7 +616,7 @@ export const createResponseBodyNode = (
       if (typeof body === "object" && body.type === "Buffer" && Array.isArray(body.data)) {
         return new Uint8Array(body.data);
       }
-      return new TextEncoder().encode(typeof body === "string" ? body : JSON.stringify(body, null, 2));
+      return new TextEncoder().encode(typeof body === "string" ? body : stringifyJsonLossless(body, 2));
     };
 
     // Render hex dump view

--- a/core-extensions/src/voiden-scripting/lib/scriptEngine.ts
+++ b/core-extensions/src/voiden-scripting/lib/scriptEngine.ts
@@ -10,6 +10,7 @@
  */
 
 import type { VdApi, ScriptLog, ScriptExecutionResult, ScriptLanguage } from './types';
+import { stringifyJsonLossless } from '../../utils/losslessJson';
 
 const SCRIPT_TIMEOUT_MS = 5_000;
 
@@ -630,7 +631,7 @@ function buildBashScript(params: {
     `export VOIDEN_REQUEST_PATH_PARAMS=${q(JSON.stringify(request?.pathParams ?? []))}`,
     `export VOIDEN_RESPONSE_STATUS=${q(has ? String(response?.status ?? '') : '')}`,
     `export VOIDEN_RESPONSE_STATUS_TEXT=${q(has ? String(response?.statusText ?? '') : '')}`,
-    `export VOIDEN_RESPONSE_BODY=${q(has && response?.body != null ? (typeof response.body === 'object' ? JSON.stringify(response.body) : String(response.body)) : '')}`,
+    `export VOIDEN_RESPONSE_BODY=${q(has && response?.body != null ? (typeof response.body === 'object' ? stringifyJsonLossless(response.body) : String(response.body)) : '')}`,
     `export VOIDEN_RESPONSE_HEADERS=${q(has ? JSON.stringify(response?.headers ?? {}) : '{}')}`,
     `export VOIDEN_RESPONSE_TIME=${q(has ? String(response?.time ?? 0) : '0')}`,
     `export VOIDEN_RESPONSE_SIZE=${q(has ? String(response?.size ?? 0) : '0')}`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9195,6 +9195,7 @@ __metadata:
     "@types/shell-quote": "npm:^1.7.1"
     "@voiden/sdk": "npm:^1.0.9"
     js-yaml: "npm:^4.1.0"
+    lossless-json: "npm:^4.0.2"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     sass: "npm:^1.89.2"
@@ -15540,6 +15541,13 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 10c0/655d110220983c1a4b9c0c679a2e8016d4b67f6e9c7b5435ff5979ecdb20d0813f4dec0a08674fcbdd4846a3f07edbb50a36811fd37930b94aaa0d9daceb017e
+  languageName: node
+  linkType: hard
+
+"lossless-json@npm:^4.0.2":
+  version: 4.3.0
+  resolution: "lossless-json@npm:4.3.0"
+  checksum: 10c0/b561eb7f77ef99dbaa0df32fa2407ddcc2c61a0d53297240f0fdd6c2e5f2e0f7d224fb055f84e76467f5ec65547540662c265fcf7a1705497a2d44e323c517df
   languageName: node
   linkType: hard
 
@@ -22210,6 +22218,7 @@ __metadata:
     js-base64: "npm:^3.7.7"
     js-cookie: "npm:^3.0.5"
     jsdom: "npm:^27.3.0"
+    lossless-json: "npm:^4.0.2"
     lucide-react: "npm:^0.474.0"
     marked: "npm:^14.1.2"
     next-themes: "npm:^0.3.0"


### PR DESCRIPTION
## Summary

- Pair each `gqlvariables` block with the executing `gqlquery` (nearest forward/backward) instead of always using the first blocks in a multi-request file.
- Pass `gqlQueryIndex` through the request orchestrator so play-button and cursor-based sends target the correct query when multiple GraphQL requests share a file.
- Preserve large JSON integers in response parsing, runtime variables, history, and the response viewer using `lossless-json` so snowflake IDs stay exact.

Addresses feedback from #256.

Closes #256
Closes #391
Closes #395
Closes #408

## Test plan

- [x] `yarn vitest run core-extensions/src/voiden-graphql/lib/graphqlBlocks.test.ts`
- [x] `yarn workspace voiden-ui vitest run src/utils/__test__/losslessJson.test.ts src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts src/core/request-engine/pipeline/__test__/pipeline.test.ts`
- [ ] Multi-request GraphQL file: send third request and confirm correct variables payload
- [ ] POST large integer to echo API; confirm exact value in UI and `{{$res.body...}}` variables