### PR TITLE
fix(request-engine): preserve big integer JSON strings in responses and runtime vars

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -27,11 +27,19 @@ describe("parseJsonPreserveIntegers", () => {
     expect(parsed.id).toBe("174322306148984899");
   });
 
-  it("preserves large integer values serialised as JSON strings (#408)", () => {
-    const parsed = parseJsonPreserveIntegers(
-      '{"response":[{"big_number_id":"333333333333333333"}]}',
-    ) as { response: Array<{ big_number_id: string }> };
-    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  it("preserves negative integers beyond MAX_SAFE_INTEGER", () => {
+    const parsed = parseJsonPreserveIntegers('{"delta":-9007199254740993}') as {
+      delta: string;
+    };
+    expect(parsed.delta).toBe("-9007199254740993");
+  });
+
+  it("preserves unsafe integers inside arrays", () => {
+    const parsed = parseJsonPreserveIntegers('{"ids":[9007199254740993,42]}') as {
+      ids: Array<string | number>;
+    };
+    expect(parsed.ids[0]).toBe("9007199254740993");
+    expect(parsed.ids[1]).toBe(42);
   });
 });
 

--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  isStructuredJsonString,
+  parseJsonPreserveIntegers,
+  prettifyJsonText,
+  safeJsonParse,
+  stringifyJsonForDisplay,
+} from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings (#395)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+
+  it("preserves large integer values serialised as JSON strings (#408)", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"response":[{"big_number_id":"333333333333333333"}]}',
+    ) as { response: Array<{ big_number_id: string }> };
+    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  });
+});
+
+describe("safeJsonParse", () => {
+  it("only parses structured JSON strings", () => {
+    expect(isStructuredJsonString('{"a":1}')).toBe(true);
+    expect(isStructuredJsonString("[1]")).toBe(true);
+    expect(isStructuredJsonString("333333333333333333")).toBe(false);
+    expect(safeJsonParse("333333333333333333")).toBe("333333333333333333");
+  });
+
+  it("uses integer-preserving parse for objects", () => {
+    const parsed = safeJsonParse('{"id":174322306148984899}') as { id: string };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+});
+
+describe("prettifyJsonText", () => {
+  it("formats JSON without corrupting string-encoded snowflake ids (#408)", () => {
+    const pretty = prettifyJsonText('{"big_number_id":"333333333333333333"}');
+    expect(pretty).toContain('"big_number_id"');
+    expect(pretty).toContain('"333333333333333333"');
+    expect(pretty).not.toContain("333333333333333300");
+  });
+
+  it("stringifyJsonForDisplay matches prettify for parsed values", () => {
+    const value = parseJsonPreserveIntegers('{"n":9007199254740992}');
+    expect(stringifyJsonForDisplay(value)).toContain('"9007199254740992"');
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,52 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so API variables stay exact.
+ * Fixes VoidenHQ/voiden#395 and VoidenHQ/voiden#408.
+ */
+
+const UNSAFE_INTEGER_TOKEN =
+  /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g;
+
+function quoteUnsafeIntegerTokens(text: string): string {
+  return text.replace(UNSAFE_INTEGER_TOKEN, (digits) => {
+    const asNumber = Number(digits);
+    return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+  });
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerTokens(text));
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function isStructuredJsonString(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+export function safeJsonParse(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  if (!isStructuredJsonString(value)) return value;
+
+  try {
+    return parseJsonPreserveIntegers(value);
+  } catch {
+    try {
+      const fixedJson = value
+        .replace(/,\s*}/g, "}")
+        .replace(/,\s*]/g, "]")
+        .replace(/,\s*$/, "");
+      return parseJsonPreserveIntegers(fixedJson);
+    } catch {
+      return value;
+    }
+  }
+}
+
+export function prettifyJsonText(text: string): string {
+  return stringifyJsonForDisplay(parseJsonPreserveIntegers(text));
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
@@ -18,6 +18,7 @@ import {
 } from './types';
 import { hookRegistry } from './HookRegistry';
 import type { Environment } from '../requestState';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Main pipeline executor class
@@ -293,7 +294,8 @@ export class PipelineExecutor {
 
     try {
       if (contentType?.includes('json')) {
-        body = await response.json();
+        const jsonText = await response.text();
+        body = parseJsonPreserveIntegers(jsonText);
       } else if (contentType?.includes('text')) {
         body = await response.text();
       } else {

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -312,7 +312,7 @@ async function parseBody(response: Response): Promise<Buffer | string | object |
   // JSON
   if (contentType.includes("json")) {
     try {
-      return await response.json();
+      return parseJsonPreserveIntegers(await response.text());
     } catch (e) {
       return await response.text(); // fallback if parsing fails
     }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString());
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,5 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
-import { safeJsonParse } from "./parseJsonPreserveIntegers";
+import { parseJsonPreserveIntegers, safeJsonParse } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -440,7 +440,7 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
                 const bodyString = JSON.stringify(requestState.body);
                 const replacedString = replaceProcessVariables(bodyString, processVariables);
                 try {
-                    requestState.body = JSON.parse(replacedString);
+                    requestState.body = parseJsonPreserveIntegers(replacedString);
                 } catch (e) {
                     // If parsing fails, keep as string
                     requestState.body = replacedString;

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { safeJsonParse } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -53,38 +54,6 @@ function findInKeyValueInKeyValue(arr: any[] | undefined, searchKey: string): an
             item.key.toLowerCase() === searchKey.toLowerCase()
     );
     return found ? found['value'] : undefined;
-}
-
-/**
- * Safely parses JSON string, returns original value if not valid JSON
- * Handles common JSON issues like trailing commas
- * @param value - The value to parse
- * @returns Parsed object or original value
- */
-function safeJsonParse(value: any): any {
-    if (typeof value !== 'string') return value;
-
-    try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
-    } catch (error) {
-        // If standard parse fails, try to fix common issues
-        try {
-            // Fix trailing commas in objects and arrays
-            const fixedJson = value
-                // Remove trailing commas in objects
-                .replace(/,\s*}/g, '}')
-                // Remove trailing commas in arrays  
-                .replace(/,\s*]/g, ']')
-                // Remove trailing commas before end of string
-                .replace(/,\s*$/, '');
-
-            return JSON.parse(fixedJson);
-        } catch {
-            // If still fails, return original value
-            return value;
-        }
-    }
 }
 
 /**
@@ -156,7 +125,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = safeJsonParse(value);
                 } catch {
                     current=value;
                 }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,7 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 
 /**
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -12,6 +12,7 @@ import * as React from "react";
 import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { AlertCircle, Check, ChevronDown, Copy, Download, Eye, FileDown, FileText, WrapText } from "lucide-react";
+import { prettifyJsonText } from "@/core/request-engine/parseJsonPreserveIntegers";
 
 type LangOption = { label: string; value: string };
 const LANG_OPTIONS: LangOption[] = [
@@ -49,7 +50,7 @@ const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript",
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary
- Add `parseJsonPreserveIntegers` so HTTP response JSON parsing keeps integers beyond `Number.MAX_SAFE_INTEGER` as exact decimal strings instead of rounding them.
- Fix `safeJsonParse` so bare numeric strings (e.g. snowflake IDs returned as JSON strings) are never re-parsed through `JSON.parse`, which was corrupting trailing digits in the response viewer and runtime variable capture.
- Apply the safe parser across all response pipeline paths and JSON prettify in the response body viewer.

## Test plan
- [x] `npm test -- --run parseJsonPreserveIntegers` (8 tests)
- [ ] Execute a request returning `{"response":[{"big_number_id":"333333333333333333"}]}` and confirm the response viewer shows the exact string value
- [ ] Capture `{{$res.body.response[0].big_number_id}}` into a runtime variable and confirm `{{process.KEY}}` resolves to `333333333333333333`
- [ ] Confirm safe integers (e.g. `42`) still parse as numbers

Closes #408