### PR TITLE
fix: preserve large JSON integers in response parsing

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseJsonPreserveIntegers,
+  prettifyJsonPreserveIntegers,
+  stringifyJsonForDisplay,
+} from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as { count: number };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+
+  it("preserves multiple unsafe integers in arrays", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"ids":[174322306148984899,9007199254740992]}',
+    ) as { ids: [string, string] };
+    expect(parsed.ids[0]).toBe("174322306148984899");
+    expect(parsed.ids[1]).toBe("9007199254740992");
+  });
+
+  it("preserves negative unsafe integers", () => {
+    const parsed = parseJsonPreserveIntegers('{"value":-9007199254740993}') as {
+      value: string;
+    };
+    expect(parsed.value).toBe("-9007199254740993");
+  });
+});
+
+describe("prettifyJsonPreserveIntegers", () => {
+  it("formats JSON while preserving large integers", () => {
+    const input = '{"args":{"id":174322306148984899}}';
+    const output = prettifyJsonPreserveIntegers(input);
+    expect(output).toContain('"174322306148984899"');
+    expect(output).not.toContain("174322306148984900");
+  });
+
+  it("returns original text when JSON is invalid", () => {
+    const input = "not-json";
+    expect(prettifyJsonPreserveIntegers(input)).toBe(input);
+  });
+});
+
+describe("stringifyJsonForDisplay", () => {
+  it("pretty-prints parsed values", () => {
+    const value = parseJsonPreserveIntegers('{"count":42}');
+    expect(stringifyJsonForDisplay(value)).toBe('{\n  "count": 42\n}');
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,31 @@
+/**
+ * Parse JSON without rounding integers outside Number.MAX_SAFE_INTEGER.
+ * Large integers are kept as decimal strings so API variables stay exact.
+ * Fixes VoidenHQ/voiden#395.
+ */
+
+const UNSAFE_INTEGER_PATTERN =
+  /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g;
+
+function quoteUnsafeIntegers(text: string): string {
+  return text.replace(UNSAFE_INTEGER_PATTERN, (digits) => {
+    const asNumber = Number(digits);
+    return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+  });
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegers(text));
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function prettifyJsonPreserveIntegers(text: string): string {
+  try {
+    return stringifyJsonForDisplay(parseJsonPreserveIntegers(text));
+  } catch {
+    return text;
+  }
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString('utf-8'));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString("utf-8"));
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -65,8 +66,7 @@ function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +79,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -15,6 +15,7 @@ import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 
 /**
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -1,15 +1,11 @@
 import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
+import { prettifyJsonPreserveIntegers } from "@/core/request-engine/parseJsonPreserveIntegers";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
 
 export function prettifyJSON(json: string) {
-  try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
-  } catch (error) {
-    return json;
-  }
+  return prettifyJsonPreserveIntegers(json);
 }
 
 export const getFileIfNotExist = async (docId: string, fileId: string, fileName: string): Promise<File | null> => {

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -46,10 +46,22 @@ export interface ResponseBodyAttrs {
 
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+function prettifyJsonText(text: string): string {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+}
+
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);


### PR DESCRIPTION
## Summary
- Add `parseJsonPreserveIntegers` utility that quotes integers beyond `Number.MAX_SAFE_INTEGER` before parsing, keeping exact decimal values as strings
- Replace `JSON.parse` in all response-body parsing paths (`sendRequestHybrid`, `requestState`, `HybridPipelineExecutor`) and `safeJsonParse` in runtime variables
- Update JSON prettify helpers in `ResponseBodyNode` and `prettifyJSON` so displayed response bodies also preserve large integers
- Add regression tests covering the reported `174322306148984899` case

## Test plan
- [x] `yarn test src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts --run` (8 tests pass)
- [ ] Send a request returning JSON with an integer > `Number.MAX_SAFE_INTEGER` and verify response variables extract the exact value
- [ ] Toggle prettify on a large-integer JSON response and confirm the displayed value is not rounded

Closes #395