### PR TITLE
fix(request-engine): preserve big integers in JSON parse paths

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseJsonPreserveIntegers,
+  safeParseJsonString,
+} from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  it("preserves integers larger than MAX_SAFE_INTEGER as strings", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"args":{"id":174322306148984899}}',
+    ) as { args: { id: string } };
+    expect(parsed.args.id).toBe("174322306148984899");
+  });
+
+  it("keeps safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"count":42}') as {
+      count: number;
+    };
+    expect(parsed.count).toBe(42);
+  });
+
+  it("does not alter strings that look like numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"id":"174322306148984899"}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("174322306148984899");
+  });
+
+  it("preserves large unquoted integers at top level", () => {
+    const parsed = parseJsonPreserveIntegers(
+      '{"id":333333333333333333}',
+    ) as { id: string };
+    expect(parsed.id).toBe("333333333333333333");
+    expect(typeof parsed.id).toBe("string");
+  });
+});
+
+describe("safeParseJsonString", () => {
+  it('does not coerce bare big integer string to number', () => {
+    const result = safeParseJsonString("333333333333333333");
+    expect(result).toBe("333333333333333333");
+    expect(typeof result).toBe("string");
+  });
+
+  it("parses JSON objects with large integers as strings", () => {
+    const result = safeParseJsonString(' {"id":333333333333333333} ') as {
+      id: string;
+    };
+    expect(result.id).toBe("333333333333333333");
+  });
+});

--- a/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/runtimeVariablesBigInt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getValueByPath, safeJsonParse } from "../runtimeVariables";
+
+describe("runtimeVariables big integer handling", () => {
+  it("safeJsonParse leaves bare big integer strings unchanged", () => {
+    expect(safeJsonParse("333333333333333333")).toBe("333333333333333333");
+  });
+
+  it("safeJsonParse preserves large integers inside JSON objects", () => {
+    const parsed = safeJsonParse('{"id":333333333333333333}') as {
+      id: string;
+    };
+    expect(parsed.id).toBe("333333333333333333");
+    expect(typeof parsed.id).toBe("string");
+  });
+
+  it("getValueByPath resolves nested large integer fields", () => {
+    const res = {
+      body: { args: { id: "174322306148984899" } },
+    };
+    expect(getValueByPath(res, "body.args.id")).toBe("174322306148984899");
+  });
+
+  it("getValueByPath parses stringified JSON without rounding big ints", () => {
+    const res = {
+      body: '{"args":{"id":333333333333333333}}',
+    };
+    expect(getValueByPath(res, "body.args.id")).toBe("333333333333333333");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,26 @@
+export function parseJsonPreserveIntegers(text: string): unknown {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const asNumber = Number(digits);
+      return Number.isSafeInteger(asNumber) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.parse(normalized);
+}
+
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function safeParseJsonString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return value;
+  }
+  try {
+    return parseJsonPreserveIntegers(value);
+  } catch {
+    return value;
+  }
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -20,6 +20,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
 
 /**
  * Hybrid pipeline executor that splits execution between UI and Electron
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString("utf-8"));
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers, safeParseJsonString } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -61,12 +62,11 @@ function findInKeyValueInKeyValue(arr: any[] | undefined, searchKey: string): an
  * @param value - The value to parse
  * @returns Parsed object or original value
  */
-function safeJsonParse(value: any): any {
+export function safeJsonParse(value: any): any {
     if (typeof value !== 'string') return value;
 
     try {
-        // First, try standard JSON parse
-        return JSON.parse(value);
+        return safeParseJsonString(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +79,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -94,7 +94,7 @@ function safeJsonParse(value: any): any {
  * @param path - Dot notation path (e.g., "headers.Authorization" or "body.data.id")
  * @returns The extracted value or undefined
  */
-function getValueByPath(obj: any, path: string): any {
+export function getValueByPath(obj: any, path: string): any {
     if (!obj || !path) return undefined;
     const keys = path.split(".");
     let current = obj;
@@ -156,7 +156,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = safeParseJsonString(value);
                 } catch {
                     current=value;
                 }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -9,6 +9,7 @@
 import { Editor, JSONContent } from "@tiptap/core";
 import { Request, BaseResponse } from "@/core/types";
 import { RestApiRequestState, RestApiResponseState } from "./pipeline/types";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 import { hookRegistry, PipelineStage } from "./pipeline";
 import { Buffer } from "buffer";
 import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables } from "./runtimeVariables";
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString("utf-8"));
         } catch {
           body = buffer.toString();
         }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -44,12 +44,29 @@ export interface ResponseBodyAttrs {
   downloadFilename: string | null;
 }
 
+
+/** Preserve integers beyond MAX_SAFE_INTEGER when prettifying JSON for display. */
+function prettifyJsonText(text: string): string {
+  const normalized = text.replace(
+    /(?<=^|[\[{:,]\s*)(-?\d+)(?=\s*[,\}\]])/g,
+    (digits) => {
+      const n = Number(digits);
+      return Number.isSafeInteger(n) ? digits : `"${digits}"`;
+    },
+  );
+  return JSON.stringify(JSON.parse(normalized), null, 2);
+}
+
+function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
 const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript", "python", "css"]);
 
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonText(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);
@@ -167,11 +184,11 @@ export const createResponseBodyNode = (
       }
       let text: string;
       if (isJson) {
-        text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        text = typeof body === "string" ? body : stringifyJsonForDisplay(body);
       } else if (isXml || isHtml || isText) {
         text = typeof body === "string" ? body : String(body);
       } else if (typeof body === "object") {
-        text = JSON.stringify(body, null, 2);
+        text = stringifyJsonForDisplay(body);
       } else {
         text = String(body);
       }
@@ -261,7 +278,7 @@ export const createResponseBodyNode = (
           const uint8Array = new Uint8Array(body.data);
           blob = new Blob([uint8Array as any], { type: contentType || "application/octet-stream" });
         } else {
-          blob = new Blob([JSON.stringify(body, null, 2)], { type: "application/json" });
+          blob = new Blob([stringifyJsonForDisplay(body)], { type: "application/json" });
         }
 
         const url = URL.createObjectURL(blob);
@@ -281,7 +298,7 @@ export const createResponseBodyNode = (
     // Copy handler
     const handleCopy = async () => {
       try {
-        const textToCopy = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        const textToCopy = typeof body === "string" ? body : stringifyJsonForDisplay(body);
         await navigator.clipboard.writeText(textToCopy);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -615,7 +632,7 @@ export const createResponseBodyNode = (
       if (typeof body === "object" && body.type === "Buffer" && Array.isArray(body.data)) {
         return new Uint8Array(body.data);
       }
-      return new TextEncoder().encode(typeof body === "string" ? body : JSON.stringify(body, null, 2));
+      return new TextEncoder().encode(typeof body === "string" ? body : stringifyJsonForDisplay(body));
     };
 
     // Render hex dump view


### PR DESCRIPTION
## Summary
- Add `parseJsonPreserveIntegers` / `safeParseJsonString` so response bodies and runtime variable path navigation keep integers beyond `Number.MAX_SAFE_INTEGER` as exact decimal strings.
- Route hybrid pipeline, secure request, and response display parsing through the new helpers; avoid `JSON.parse` on bare numeric strings during `safeJsonParse`.
- Add unit tests for parser helpers and runtime variable big-int behavior.

## Test plan
- [x] `yarn test --run parseJsonPreserveIntegers runtimeVariablesBigInt` (10 tests passed)
- [ ] Send a request whose JSON response contains an ID > `MAX_SAFE_INTEGER` and confirm response variables retain the exact value
- [ ] Confirm a runtime variable path into a stringified JSON field with a large integer does not round

Closes #408