### PR TITLE
fix: preserve large integer precision in responses and runtime vars

### DIFF
--- a/apps/ui/src/core/history/pipelineHooks.ts
+++ b/apps/ui/src/core/history/pipelineHooks.ts
@@ -12,6 +12,7 @@ import { useHistoryStore } from './historyStore';
 import { appendToHistory } from './historyManager';
 import { useResponseStore } from '@/core/request-engine/stores/responseStore';
 import { historyAdapterRegistry } from './adapterRegistry';
+import { stringifyJsonForDisplay } from '@/core/request-engine/parseJsonPreserveIntegers';
 
 /** Cached between pre-processing and post-processing within a single request */
 let cachedFilePath: string | null = null;
@@ -230,7 +231,7 @@ async function buildFallbackEntry(requestState: any, responseState: any, project
     try {
       const raw = typeof responseState.body === 'string'
         ? responseState.body
-        : JSON.stringify(responseState.body, null, 2);
+        : stringifyJsonForDisplay(responseState.body);
       responseBody = raw.length > 102400 ? raw.slice(0, 102400) + '\n… (truncated)' : raw;
     } catch { /* skip */ }
   }

--- a/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/parseJsonPreserveIntegers.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  isUnsafeIntegerString,
+  parseJsonPreserveIntegers,
+  prettifyJsonPreserveIntegers,
+  stringifyJsonForDisplay,
+} from "../parseJsonPreserveIntegers";
+
+describe("parseJsonPreserveIntegers", () => {
+  const BUG_CASE = "174322306148984899";
+
+  it("detects unsafe integers via BigInt comparison", () => {
+    expect(Number(BUG_CASE)).toBe(174322306148984900);
+    expect(isUnsafeIntegerString(BUG_CASE)).toBe(true);
+  });
+
+  it("preserves issue #395 large integer in parsed JSON", () => {
+    const json = `{"args":{"id":${BUG_CASE}}}`;
+    const parsed = parseJsonPreserveIntegers(json) as { args: { id: string } };
+    expect(parsed.args.id).toBe(BUG_CASE);
+    expect(JSON.parse(json).args.id).toBe(174322306148984900);
+  });
+
+  it("leaves safe integers as numbers", () => {
+    const parsed = parseJsonPreserveIntegers('{"n":42,"max":9007199254740991}') as {
+      n: number;
+      max: number;
+    };
+    expect(parsed.n).toBe(42);
+    expect(parsed.max).toBe(9007199254740991);
+  });
+
+  it("does not alter numbers inside JSON strings", () => {
+    const json = `{"s":"value ${BUG_CASE} here"}`;
+    const parsed = parseJsonPreserveIntegers(json) as { s: string };
+    expect(parsed.s).toBe(`value ${BUG_CASE} here`);
+  });
+
+  it("prettifies while preserving large integers without rounding", () => {
+    const pretty = prettifyJsonPreserveIntegers(`{"args":{"id":${BUG_CASE}}}`);
+    expect(pretty).toContain(BUG_CASE);
+    expect(pretty).not.toContain("174322306148984900");
+    expect(pretty).not.toContain(`"${BUG_CASE}"`);
+  });
+
+  it("stringifyJsonForDisplay unquotes preserved large integers", () => {
+    const parsed = parseJsonPreserveIntegers(`{"id":${BUG_CASE}}`);
+    const display = stringifyJsonForDisplay(parsed);
+    expect(display).toContain(`"id": ${BUG_CASE}`);
+  });
+
+  it("preserves issue #408 snowflake ID in response array", () => {
+    const json = '{"response":[{"big_number_id":333333333333333333}]}';
+    const parsed = parseJsonPreserveIntegers(json) as {
+      response: Array<{ big_number_id: string }>;
+    };
+    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  });
+
+  it("preserves issue #408 snowflake ID when already a JSON string", () => {
+    const json = '{"response":[{"big_number_id":"333333333333333333"}]}';
+    const parsed = parseJsonPreserveIntegers(json) as {
+      response: Array<{ big_number_id: string }>;
+    };
+    expect(parsed.response[0].big_number_id).toBe("333333333333333333");
+  });
+});

--- a/apps/ui/src/core/request-engine/__test__/runtimeVariables.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/runtimeVariables.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getValueByPath } from "../runtimeVariables";
+import { parseJsonPreserveIntegers } from "../parseJsonPreserveIntegers";
+
+describe("runtime variable path extraction", () => {
+  it("extracts large integer IDs without precision loss for issue #408", () => {
+    const responseBody = parseJsonPreserveIntegers(
+      '{"response":[{"big_number_id":333333333333333333}]}',
+    );
+
+    const value = getValueByPath(
+      { body: responseBody },
+      "body.response[0].big_number_id",
+    );
+
+    expect(value).toBe("333333333333333333");
+  });
+
+  it("extracts quoted large integer strings unchanged for issue #408", () => {
+    const responseBody = parseJsonPreserveIntegers(
+      '{"response":[{"big_number_id":"333333333333333333"}]}',
+    );
+
+    const value = getValueByPath(
+      { body: responseBody },
+      "body.response[0].big_number_id",
+    );
+
+    expect(value).toBe("333333333333333333");
+  });
+});

--- a/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
+++ b/apps/ui/src/core/request-engine/parseJsonPreserveIntegers.ts
@@ -1,0 +1,99 @@
+/**
+ * JSON.parse rounds integers that exceed Number.MAX_SAFE_INTEGER (and other
+ * integers not exactly representable as IEEE-754 doubles). Quote those
+ * literals before parsing so they remain strings in the resulting object.
+ *
+ * @see https://github.com/VoidenHQ/voiden/issues/408, https://github.com/VoidenHQ/voiden/issues/395
+ */
+
+export function isUnsafeIntegerString(digits: string): boolean {
+  if (!/^-?(?:0|[1-9]\d*)$/.test(digits)) {
+    return false;
+  }
+  try {
+    const asBigInt = BigInt(digits);
+    const asNumber = Number(digits);
+    if (!Number.isFinite(asNumber)) {
+      return true;
+    }
+    return asBigInt !== BigInt(asNumber);
+  } catch {
+    return false;
+  }
+}
+
+const JSON_NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+
+function quoteUnsafeIntegerLiterals(text: string): string {
+  let out = "";
+  let i = 0;
+  const length = text.length;
+
+  while (i < length) {
+    const char = text[i];
+
+    if (char === '"') {
+      out += char;
+      i += 1;
+      while (i < length) {
+        const inner = text[i];
+        out += inner;
+        if (inner === "\\") {
+          i += 1;
+          if (i < length) {
+            out += text[i];
+            i += 1;
+          }
+        } else if (inner === '"') {
+          i += 1;
+          break;
+        } else {
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    if (char === "-" || (char >= "0" && char <= "9")) {
+      const rest = text.slice(i);
+      const match = rest.match(JSON_NUMBER);
+      if (match && match.index === 0) {
+        const token = match[0];
+        const isInteger = !token.includes(".") && !/[eE]/.test(token);
+        if (isInteger && isUnsafeIntegerString(token)) {
+          out += `"${token}"`;
+        } else {
+          out += token;
+        }
+        i += token.length;
+        continue;
+      }
+    }
+
+    out += char;
+    i += 1;
+  }
+
+  return out;
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerLiterals(text));
+}
+
+/** Render parsed JSON for UI, unquoting preserved large integer strings. */
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2).replace(
+    /"(-?\d+)"/g,
+    (match, digits: string) => (isUnsafeIntegerString(digits) ? digits : match),
+  );
+}
+
+export function prettifyJsonPreserveIntegers(text: string): string {
+  try {
+    const parsed = parseJsonPreserveIntegers(text);
+    return stringifyJsonForDisplay(parsed);
+  } catch {
+    return text;
+  }
+}

--- a/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/HybridPipelineExecutor.ts
@@ -19,6 +19,7 @@ import {
   PreSendContext,
   PostProcessingContext,
 } from './types';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 import { hookRegistry } from './HookRegistry';
 
 /**
@@ -221,7 +222,7 @@ export class HybridPipelineExecutor {
 
       if (contentType.includes('json')) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString());
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
+++ b/apps/ui/src/core/request-engine/pipeline/PipelineExecutor.ts
@@ -17,6 +17,7 @@ import {
   PostProcessingContext,
 } from './types';
 import { hookRegistry } from './HookRegistry';
+import { parseJsonPreserveIntegers } from '../parseJsonPreserveIntegers';
 import type { Environment } from '../requestState';
 
 /**
@@ -293,7 +294,7 @@ export class PipelineExecutor {
 
     try {
       if (contentType?.includes('json')) {
-        body = await response.json();
+        body = parseJsonPreserveIntegers(await response.text());
       } else if (contentType?.includes('text')) {
         body = await response.text();
       } else {

--- a/apps/ui/src/core/request-engine/requestState.ts
+++ b/apps/ui/src/core/request-engine/requestState.ts
@@ -19,6 +19,7 @@ import { Proxy } from "@/core/types";
 import { Buffer } from "buffer";
 import { RestApiRequestState } from "./pipeline/types";
 import { replaceProcessVariablesInText } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 export interface EnvironmentVariable {
   key: string;
@@ -311,7 +312,7 @@ async function parseBody(response: Response): Promise<Buffer | string | object |
   // JSON
   if (contentType.includes("json")) {
     try {
-      return await response.json();
+      return parseJsonPreserveIntegers(await response.text());
     } catch (e) {
       return await response.text(); // fallback if parsing fails
     }
@@ -332,7 +333,7 @@ async function parseBodyFromBytes(bytes: Buffer, contentType: string | null): Pr
   // Handle JSON content type.
   if (contentType?.includes("json")) {
     try {
-      return JSON.parse(bytes.toString());
+      return parseJsonPreserveIntegers(bytes.toString());
     } catch (error) {
       // Fallback to returning the raw string if JSON parsing fails.
       return bytes.toString();
@@ -819,7 +820,7 @@ export async function sendRequestSecure(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString());
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -1,4 +1,5 @@
 import { parseCookies } from "@voiden/sdk/shared";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 
 interface RuntimeVariable {
     key: string;
@@ -66,7 +67,7 @@ function safeJsonParse(value: any): any {
 
     try {
         // First, try standard JSON parse
-        return JSON.parse(value);
+        return parseJsonPreserveIntegers(value);
     } catch (error) {
         // If standard parse fails, try to fix common issues
         try {
@@ -79,7 +80,7 @@ function safeJsonParse(value: any): any {
                 // Remove trailing commas before end of string
                 .replace(/,\s*$/, '');
 
-            return JSON.parse(fixedJson);
+            return parseJsonPreserveIntegers(fixedJson);
         } catch {
             // If still fails, return original value
             return value;
@@ -94,7 +95,7 @@ function safeJsonParse(value: any): any {
  * @param path - Dot notation path (e.g., "headers.Authorization" or "body.data.id")
  * @returns The extracted value or undefined
  */
-function getValueByPath(obj: any, path: string): any {
+export function getValueByPath(obj: any, path: string): any {
     if (!obj || !path) return undefined;
     const keys = path.split(".");
     let current = obj;
@@ -156,7 +157,7 @@ function getValueByPath(obj: any, path: string): any {
             }
             if (value) {
                 try {
-                    current = JSON.parse(value);
+                    current = parseJsonPreserveIntegers(value);
                 } catch {
                     current=value;
                 }
@@ -471,7 +472,7 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
                 const bodyString = JSON.stringify(requestState.body);
                 const replacedString = replaceProcessVariables(bodyString, processVariables);
                 try {
-                    requestState.body = JSON.parse(replacedString);
+                    requestState.body = parseJsonPreserveIntegers(replacedString);
                 } catch (e) {
                     // If parsing fails, keep as string
                     requestState.body = replacedString;

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -12,6 +12,7 @@ import { RestApiRequestState, RestApiResponseState } from "./pipeline/types";
 import { hookRegistry, PipelineStage } from "./pipeline";
 import { Buffer } from "buffer";
 import { preSendProcessHook, replaceProcessVariablesInText, saveRuntimeVariables } from "./runtimeVariables";
+import { parseJsonPreserveIntegers } from "./parseJsonPreserveIntegers";
 import { get } from "http";
 import { getRuntimeVariablesMap } from "./getRequestFromJson";
 import { expandLinkedBlocksInDoc } from "../editors/voiden/utils/expandLinkedBlocks";
@@ -414,7 +415,7 @@ export async function sendRequestHybrid(
 
       if (contentType.includes("json")) {
         try {
-          body = JSON.parse(buffer.toString());
+          body = parseJsonPreserveIntegers(buffer.toString());
         } catch {
           body = buffer.toString();
         }

--- a/apps/ui/src/utils/index.ts
+++ b/apps/ui/src/utils/index.ts
@@ -1,15 +1,11 @@
 import { createFileFromS3Url, getSignedUrl } from "@/apis/files";
+import { prettifyJsonPreserveIntegers } from "@/core/request-engine/parseJsonPreserveIntegers";
 import { JSONContent } from "@tiptap/core";
 import { yXmlFragmentToProsemirrorJSON } from "y-prosemirror";
 import * as Y from "yjs";
 
 export function prettifyJSON(json: string) {
-  try {
-    const parsedJSON = JSON.parse(json);
-    return JSON.stringify(parsedJSON, null, 2);
-  } catch (error) {
-    return json;
-  }
+  return prettifyJsonPreserveIntegers(json);
 }
 
 export const getFileIfNotExist = async (docId: string, fileId: string, fileName: string): Promise<File | null> => {

--- a/core-extensions/src/utils/parseJsonPreserveIntegers.ts
+++ b/core-extensions/src/utils/parseJsonPreserveIntegers.ts
@@ -1,0 +1,99 @@
+/**
+ * JSON.parse rounds integers that exceed Number.MAX_SAFE_INTEGER (and other
+ * integers not exactly representable as IEEE-754 doubles). Quote those
+ * literals before parsing so they remain strings in the resulting object.
+ *
+ * @see https://github.com/VoidenHQ/voiden/issues/408, https://github.com/VoidenHQ/voiden/issues/395
+ */
+
+export function isUnsafeIntegerString(digits: string): boolean {
+  if (!/^-?(?:0|[1-9]\d*)$/.test(digits)) {
+    return false;
+  }
+  try {
+    const asBigInt = BigInt(digits);
+    const asNumber = Number(digits);
+    if (!Number.isFinite(asNumber)) {
+      return true;
+    }
+    return asBigInt !== BigInt(asNumber);
+  } catch {
+    return false;
+  }
+}
+
+const JSON_NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+
+function quoteUnsafeIntegerLiterals(text: string): string {
+  let out = "";
+  let i = 0;
+  const length = text.length;
+
+  while (i < length) {
+    const char = text[i];
+
+    if (char === '"') {
+      out += char;
+      i += 1;
+      while (i < length) {
+        const inner = text[i];
+        out += inner;
+        if (inner === "\\") {
+          i += 1;
+          if (i < length) {
+            out += text[i];
+            i += 1;
+          }
+        } else if (inner === '"') {
+          i += 1;
+          break;
+        } else {
+          i += 1;
+        }
+      }
+      continue;
+    }
+
+    if (char === "-" || (char >= "0" && char <= "9")) {
+      const rest = text.slice(i);
+      const match = rest.match(JSON_NUMBER);
+      if (match && match.index === 0) {
+        const token = match[0];
+        const isInteger = !token.includes(".") && !/[eE]/.test(token);
+        if (isInteger && isUnsafeIntegerString(token)) {
+          out += `"${token}"`;
+        } else {
+          out += token;
+        }
+        i += token.length;
+        continue;
+      }
+    }
+
+    out += char;
+    i += 1;
+  }
+
+  return out;
+}
+
+export function parseJsonPreserveIntegers(text: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerLiterals(text));
+}
+
+/** Render parsed JSON for UI, unquoting preserved large integer strings. */
+export function stringifyJsonForDisplay(value: unknown): string {
+  return JSON.stringify(value, null, 2).replace(
+    /"(-?\d+)"/g,
+    (match, digits: string) => (isUnsafeIntegerString(digits) ? digits : match),
+  );
+}
+
+export function prettifyJsonPreserveIntegers(text: string): string {
+  try {
+    const parsed = parseJsonPreserveIntegers(text);
+    return stringifyJsonForDisplay(parsed);
+  } catch {
+    return text;
+  }
+}

--- a/core-extensions/src/voiden-rest-api/historyAdapter.tsx
+++ b/core-extensions/src/voiden-rest-api/historyAdapter.tsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useState } from 'react';
+import { stringifyJsonForDisplay } from '../utils/parseJsonPreserveIntegers';
 
 // ─── Adapter contract types (mirrors adapterRegistry — defined locally to avoid cross-rootDir import) ──
 
@@ -360,7 +361,7 @@ async function captureEntry(pipelineContext: any): Promise<HistoryPluginEntry & 
     try {
       const raw = typeof responseState.body === 'string'
         ? responseState.body
-        : JSON.stringify(responseState.body, null, 2);
+        : stringifyJsonForDisplay(responseState.body);
       responseBody = raw.length > 102400 ? raw.slice(0, 102400) + '\n… (truncated)' : raw;
     } catch { /* skip */ }
   }

--- a/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
+++ b/core-extensions/src/voiden-rest-api/nodes/ResponseBodyNode.tsx
@@ -8,6 +8,7 @@
  * - Structured like request blocks with header and options
  */
 
+import { prettifyJsonPreserveIntegers, stringifyJsonForDisplay } from "../../utils/parseJsonPreserveIntegers";
 import * as React from "react";
 import { Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
@@ -49,7 +50,7 @@ const PRETTIFIABLE_LANGS = new Set(["json", "xml", "html", "yaml", "javascript",
 const prettifyContent = (text: string, lang: string): string => {
   try {
     if (lang === "json") {
-      return JSON.stringify(JSON.parse(text), null, 2);
+      return prettifyJsonPreserveIntegers(text);
     }
     if (lang === "xml" || lang === "html") {
       return prettifyHtml(text);
@@ -167,11 +168,11 @@ export const createResponseBodyNode = (
       }
       let text: string;
       if (isJson) {
-        text = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        text = typeof body === "string" ? body : stringifyJsonForDisplay(body);
       } else if (isXml || isHtml || isText) {
         text = typeof body === "string" ? body : String(body);
       } else if (typeof body === "object") {
-        text = JSON.stringify(body, null, 2);
+        text = stringifyJsonForDisplay(body);
       } else {
         text = String(body);
       }
@@ -261,7 +262,7 @@ export const createResponseBodyNode = (
           const uint8Array = new Uint8Array(body.data);
           blob = new Blob([uint8Array as any], { type: contentType || "application/octet-stream" });
         } else {
-          blob = new Blob([JSON.stringify(body, null, 2)], { type: "application/json" });
+          blob = new Blob([stringifyJsonForDisplay(body)], { type: "application/json" });
         }
 
         const url = URL.createObjectURL(blob);
@@ -281,7 +282,7 @@ export const createResponseBodyNode = (
     // Copy handler
     const handleCopy = async () => {
       try {
-        const textToCopy = typeof body === "string" ? body : JSON.stringify(body, null, 2);
+        const textToCopy = typeof body === "string" ? body : stringifyJsonForDisplay(body);
         await navigator.clipboard.writeText(textToCopy);
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
@@ -615,7 +616,7 @@ export const createResponseBodyNode = (
       if (typeof body === "object" && body.type === "Buffer" && Array.isArray(body.data)) {
         return new Uint8Array(body.data);
       }
-      return new TextEncoder().encode(typeof body === "string" ? body : JSON.stringify(body, null, 2));
+      return new TextEncoder().encode(typeof body === "string" ? body : stringifyJsonForDisplay(body));
     };
 
     // Render hex dump view


### PR DESCRIPTION
## Summary

- Fixes #408 where large integer values (e.g. snowflake IDs like `333333333333333333`) were silently rounded when JSON response bodies were parsed with `JSON.parse()`
- Adds `parseJsonPreserveIntegers` utility that quotes unsafe integer literals before parsing, keeping exact digits as strings internally
- Updates all response parsing paths (`sendRequestHybrid`, `requestState`, pipeline executors), the response body viewer display layer, history serialization, and runtime variable capture (`{{$res.body...}}`)

## Root cause

`JSON.parse()` coerces JSON number tokens into IEEE-754 doubles. Integers beyond `Number.MAX_SAFE_INTEGER` (or values that round during coercion, like `333333333333333333` → `333333333333333300`) lose trailing digits. The corrupted values propagated through the response viewer and runtime variable capture.

## Test plan

- [x] `parseJsonPreserveIntegers.test.ts` — 8 unit tests including issue #408 fixtures (numeric and string-encoded snowflake IDs)
- [x] `runtimeVariables.test.ts` — verifies `{{$res.body.response[0].big_number_id}}` path extraction preserves exact digits
- [ ] Manual: execute a request returning `{"response":[{"big_number_id":"333333333333333333"}]}` and confirm response viewer shows exact value
- [ ] Manual: capture `{{$res.body.response[0].big_number_id}}` into a runtime variable and verify exact digits in `.voiden/.process.env.json`


Made with [Cursor](https://cursor.com)