### PR TITLE
Improve keyboard navigation and nesting experience for blocks (#449)

### DIFF
--- a/apps/ui/src/core/editors/voiden/extensions/seamlessNavigation.ts
+++ b/apps/ui/src/core/editors/voiden/extensions/seamlessNavigation.ts
@@ -38,6 +38,68 @@ export const SeamlessNavigation = Extension.create({
                 modifierKeyPressed = true;
               }
 
+              // Skip non-navigable blocks (e.g., binary file uploads) when
+              // arrow keys can't move the cursor past them
+              if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
+                  !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
+                const oldPos = view.state.selection.$anchor.pos;
+                const isDown = event.key === 'ArrowDown';
+
+                setTimeout(() => {
+                  // If cursor moved, ProseMirror handled it — nothing to do
+                  if (view.state.selection.$anchor.pos !== oldPos) return;
+
+                  const { state } = view;
+                  const { doc } = state;
+
+                  // Find which top-level block the cursor is in
+                  let blockStart = 0;
+                  let currentBlockIndex = -1;
+                  for (let i = 0; i < doc.childCount; i++) {
+                    const child = doc.child(i);
+                    const blockEnd = blockStart + child.nodeSize;
+                    if (oldPos >= blockStart && oldPos < blockEnd) {
+                      currentBlockIndex = i;
+                      break;
+                    }
+                    blockStart = blockEnd;
+                  }
+                  if (currentBlockIndex === -1) return;
+
+                  // Search in the movement direction for a block with editable text
+                  const step = isDown ? 1 : -1;
+                  for (let idx = currentBlockIndex + step; idx >= 0 && idx < doc.childCount; idx += step) {
+                    let bPos = 0;
+                    for (let j = 0; j < idx; j++) {
+                      bPos += doc.child(j).nodeSize;
+                    }
+                    const block = doc.child(idx);
+
+                    if (isDown) {
+                      for (let p = bPos + 1; p < bPos + block.nodeSize; p++) {
+                        try {
+                          const $p = doc.resolve(p);
+                          if ($p.parent.isTextblock && $p.parent.type.spec.content?.includes('inline')) {
+                            view.dispatch(state.tr.setSelection(TextSelection.create(doc, p)));
+                            return;
+                          }
+                        } catch (e) { /* position not resolvable */ }
+                      }
+                    } else {
+                      for (let p = bPos + block.nodeSize - 1; p > bPos; p--) {
+                        try {
+                          const $p = doc.resolve(p);
+                          if ($p.parent.isTextblock && $p.parent.type.spec.content?.includes('inline')) {
+                            view.dispatch(state.tr.setSelection(TextSelection.create(doc, p)));
+                            return;
+                          }
+                        } catch (e) { /* position not resolvable */ }
+                      }
+                    }
+                  }
+                }, 10);
+              }
+
               return false;
             },
 

--- a/apps/ui/src/core/editors/voiden/extensions/tabHandler.ts
+++ b/apps/ui/src/core/editors/voiden/extensions/tabHandler.ts
@@ -14,16 +14,23 @@ export const TabHandler = Extension.create({
 
         // Check if we're at the start of a list item
         if (editor.isActive("listItem")) {
-          // Attempt to sink the list item
-          const sinkResult = editor.chain().sinkListItem("listItem").run();
+          // Prevent accidental deep nesting by limiting indent depth
+          const { $from } = editor.state.selection;
+          let listDepth = 0;
+          for (let d = $from.depth; d > 0; d--) {
+            if ($from.node(d).type.name === 'listItem') {
+              listDepth++;
+            }
+          }
 
-          // If sinking was successful, return true
-          // If sinking failed, we do nothing
-          if (sinkResult) {
-            return true;
-          } else {
+          // Cap nesting at 3 levels to avoid runaway indentation
+          if (listDepth >= 3) {
             return true;
           }
+
+          // Attempt to sink the list item (indent one level)
+          editor.chain().sinkListItem("listItem").run();
+          return true;
         }
 
         editor


### PR DESCRIPTION
## Summary

This PR improves keyboard navigation and nesting behavior in the editor.

## Before

<img width="1470" height="956" alt="Screenshot 2026-06-16 at 4 43 39 PM" src="https://github.com/user-attachments/assets/a5f5e6f1-63c3-4538-80c9-6c6ccfc99057" />
<img width="1470" height="956" alt="Screenshot 2026-06-16 at 4 47 29 PM" src="https://github.com/user-attachments/assets/4457630c-b75c-49ec-a533-0227d381283c" />

### Changes

- Cap list item nesting depth at 3 levels to prevent accidental deep indentation when pressing Tab repeatedly
- Skip non-navigable blocks (e.g. binary file uploads) during arrow key navigation so the cursor no longer gets stuck on blocks without editable text content

 ### Testing
- Verified maximum nesting depth is enforced.
- Tested keyboard navigation across different block types.
- Confirmed non-navigable blocks are skipped during navigation.

Closes #449 