### PR TITLE
Improve Auth Block UI

### DIFF
--- a/apps/electron/src/renderer/components/AuthBlock.tsx
+++ b/apps/electron/src/renderer/components/AuthBlock.tsx
@@ -1,0 +1,7 @@
+return (
+  <div>
+    <input type="text" value={username} onChange={(e) => setUsername(e.target.value)} />
+    <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+    <div style={{ marginLeft: '20px' }}>Value: {value}</div>
+  </div>
+);


### PR DESCRIPTION
## What was broken
The Advanced Authentication → Basic Auth UI did not clearly indicate the Value column.
## What changed
Added a clear indication of the Value column in the Advanced Authentication → Basic Auth UI.
## How to test
Configure Advanced Authentication → Basic Auth and verify that the Value column is clearly visible.

---
_Opened by autonomous agent. Human review required before merge._