### PR TITLE
fix: parse YAML env files in runner --env option

### DIFF
--- a/packages/voiden-runner/src/__test__/envFile.test.ts
+++ b/packages/voiden-runner/src/__test__/envFile.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { loadEnvFile } from '../envFile.js'
+
+describe('loadEnvFile', () => {
+  let dir: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'voiden-env-'))
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const write = (name: string, content: string): string => {
+    const filePath = join(dir, name)
+    writeFileSync(filePath, content, 'utf-8')
+    return filePath
+  }
+
+  it('parses KEY=VALUE .env files, stripping quotes and skipping comments', () => {
+    const filePath = write('vars.env', '# comment\nFOO=bar\nTOKEN="secret"\n\nQUOTED=\'q\'\n')
+    expect(loadEnvFile(filePath)).toEqual({ FOO: 'bar', TOKEN: 'secret', QUOTED: 'q' })
+  })
+
+  it('still throws on a malformed .env line missing "="', () => {
+    const filePath = write('bad.env', 'FOO bar\n')
+    expect(() => loadEnvFile(filePath)).toThrow('Malformed line 1 in .env file: missing "="')
+  })
+
+  it('parses a flat YAML mapping', () => {
+    const filePath = write('flat.yaml', 'FOO: bar\n')
+    expect(loadEnvFile(filePath)).toEqual({ FOO: 'bar' })
+  })
+
+  it('parses the app-style nested env tree (env-public.yaml shape)', () => {
+    const filePath = write('env-public.yaml', 'test:\n  variables:\n    BASE_URL: https://echo.apyhub.com\n')
+    expect(loadEnvFile(filePath)).toEqual({ BASE_URL: 'https://echo.apyhub.com' })
+  })
+
+  it('merges nested children, with child values overriding inherited ones', () => {
+    const filePath = write('tree.yaml', [
+      'base:',
+      '  variables:',
+      '    HOST: example.com',
+      '    TOKEN: parent',
+      '  children:',
+      '    staging:',
+      '      variables:',
+      '        TOKEN: child',
+      '',
+    ].join('\n'))
+    expect(loadEnvFile(filePath)).toEqual({ HOST: 'example.com', TOKEN: 'child' })
+  })
+
+  it('supports the .yml extension and coerces scalar values to strings', () => {
+    const filePath = write('env.yml', 'PORT: 8080\nDEBUG: true\n')
+    expect(loadEnvFile(filePath)).toEqual({ PORT: '8080', DEBUG: 'true' })
+  })
+
+  it('returns an empty map for an empty or comment-only YAML file', () => {
+    const filePath = write('empty.yaml', '# nothing here\n')
+    expect(loadEnvFile(filePath)).toEqual({})
+  })
+
+  it('throws on a .env line with an empty key', () => {
+    const filePath = write('emptykey.env', '=oops\n')
+    expect(() => loadEnvFile(filePath)).toThrow('Malformed line 1 in .env file: empty key')
+  })
+
+  it('matches the file extension case-insensitively (.YAML)', () => {
+    const filePath = write('upper.YAML', 'FOO: bar\n')
+    expect(loadEnvFile(filePath)).toEqual({ FOO: 'bar' })
+  })
+
+  it('skips keys with no value (null) in YAML', () => {
+    const filePath = write('nullval.yaml', 'FOO: bar\nEMPTY:\n')
+    expect(loadEnvFile(filePath)).toEqual({ FOO: 'bar' })
+  })
+
+  it('returns an empty map when the YAML root is not a mapping', () => {
+    const filePath = write('scalar.yaml', 'just a bare string\n')
+    expect(loadEnvFile(filePath)).toEqual({})
+  })
+})

--- a/packages/voiden-runner/src/envFile.ts
+++ b/packages/voiden-runner/src/envFile.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'fs'
+import { extname } from 'path'
+import YAML from 'yaml'
+
+interface YamlEnvNode {
+  variables?: Record<string, unknown>
+  children?: Record<string, YamlEnvNode>
+}
+
+export function loadEnvFile(envPath: string): Record<string, string> {
+  const content = readFileSync(envPath, 'utf-8')
+  const ext = extname(envPath).toLowerCase()
+
+  if (ext === '.yaml' || ext === '.yml') {
+    return parseYamlEnv(content)
+  }
+
+  return parseDotEnv(content)
+}
+
+function parseDotEnv(content: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  const lines = content.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) throw new Error(`Malformed line ${i + 1} in .env file: missing "="`)
+    const key = line.slice(0, eq).trim()
+    const val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
+    if (!key) throw new Error(`Malformed line ${i + 1} in .env file: empty key`)
+    env[key] = val
+  }
+  return env
+}
+
+function parseYamlEnv(content: string): Record<string, string> {
+  const env: Record<string, string> = {}
+
+  const collect = (tree: Record<string, unknown>): void => {
+    for (const [key, value] of Object.entries(tree)) {
+      if (value === null || value === undefined || Array.isArray(value)) continue
+
+      if (typeof value !== 'object') {
+        env[key] = String(value)
+        continue
+      }
+
+      const node = value as YamlEnvNode
+      const hasVariables = node.variables != null && typeof node.variables === 'object'
+      const hasChildren = node.children != null && typeof node.children === 'object'
+
+      if (hasVariables) {
+        for (const [k, v] of Object.entries(node.variables as Record<string, unknown>)) {
+          if (v != null && typeof v !== 'object') env[k] = String(v)
+        }
+      }
+      if (hasChildren) collect(node.children as Record<string, unknown>)
+    }
+  }
+
+  const parsed = YAML.parse(content)
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    collect(parsed as Record<string, unknown>)
+  }
+  return env
+}

--- a/packages/voiden-runner/src/index.ts
+++ b/packages/voiden-runner/src/index.ts
@@ -36,6 +36,7 @@ import {
   getMcpStatus,
   MCP_SKILL_MARKDOWN,
 } from '@voiden/executors'
+import { loadEnvFile } from './envFile.js'
 import {
   appendSessionResults,
   loadSessionResults,
@@ -66,24 +67,6 @@ const JSON_SCHEMA_VERSION = '1'
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
-
-function loadEnvFile(envPath: string): Record<string, string> {
-  const content = readFileSync(envPath, 'utf-8')
-  const env: Record<string, string> = {}
-  const lines = content.split('\n')
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim()
-    if (!line || line.startsWith('#')) continue
-    const eq = line.indexOf('=')
-    if (eq === -1) throw new Error(`Malformed line ${i + 1} in .env file: missing "="`)
-    const key = line.slice(0, eq).trim()
-    const val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
-    if (!key) throw new Error(`Malformed line ${i + 1} in .env file: empty key`)
-    env[key] = val
-  }
-  return env
-}
-
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`

--- a/packages/voiden-runner/tsconfig.json
+++ b/packages/voiden-runner/tsconfig.json
@@ -13,5 +13,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/voiden-sdk-audio.ts", "src/audio", "src/ui", "src/examples"]
+  "exclude": ["node_modules", "dist", "src/voiden-sdk-audio.ts", "src/audio", "src/ui", "src/examples", "src/**/*.test.ts", "src/**/__test__"]
 }


### PR DESCRIPTION
Fixes #522

## Problem
`run --env` advertises it accepts a `.env` or `.yaml` file, but `loadEnvFile` parsed every file as dotenv and threw `Malformed line ... missing "="` on any YAML file.

## Fix
`loadEnvFile` (extracted to `envFile.ts` for testability) now dispatches on extension: `.yaml`/`.yml` are parsed with the `yaml` package and flattened into the runner's flat variable map, supporting both a plain `KEY: value` mapping and the app's nested `variables`/`children` tree (mirroring `apps/electron/src/main/env.ts`). `.env` behaviour is unchanged.

## Tests
`src/__test__/envFile.test.ts` (vitest, 11 cases): dotenv parsing + malformed/empty-key throws, flat YAML, nested tree, child-inheritance override, `.yml`, uppercase extension, scalar coercion, null values, non-mapping root, and empty files.