### PR TITLE
fix: resolve voiden-runner failure on Postman/OpenAPI imported .void files (#509)

### DIFF
--- a/apps/ui/src/core/editors/voiden/__test__/helpers.test.ts
+++ b/apps/ui/src/core/editors/voiden/__test__/helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertBlocksToVoidFile,
+  createMethodNode,
+  createUrlNode,
+  createHeadersTableNode,
+  createQueryTableNode,
+} from "../../../../../../../plugins/voiden-rest-api/src/lib/helpers";
+import { buildRequest } from "../../../../../../../plugins/voiden-rest-api/src/runner";
+import { parseVoidFile } from "../../../../../../../packages/voiden-runner/src/parser";
+
+describe("convertBlocksToVoidFile - runner compatibility", () => {
+  it("simplifies raw method, url, and table nodes into runner-compatible format", () => {
+    const rawBlocks = [
+      {
+        type: "request",
+        content: [
+          createMethodNode("POST"),
+          createUrlNode("https://api.example.com/v1/users"),
+        ],
+      },
+      createHeadersTableNode([
+        ["Authorization", "Bearer token123"],
+        ["Content-Type", "application/json"],
+      ]),
+      createQueryTableNode([
+        ["page", "1"],
+        ["limit", "10"],
+      ]),
+    ];
+
+    const markdownOutput = convertBlocksToVoidFile("Test Request", rawBlocks);
+
+    // 1. Verify markdown output string formatting
+    expect(markdownOutput).toContain("# Test Request");
+    expect(markdownOutput).toContain("method: POST");
+    expect(markdownOutput).toContain("content: https://api.example.com/v1/users");
+    expect(markdownOutput).toContain("- Authorization");
+    expect(markdownOutput).toContain("- Bearer token123");
+
+    // 2. Parse back via voiden-runner's parser
+    const parsedBlocks = parseVoidFile(markdownOutput);
+    expect(parsedBlocks.length).toBe(3);
+
+    // 3. Build request using voiden-rest-api's runner buildRequest
+    const requestState = buildRequest(parsedBlocks);
+    expect(requestState).not.toBeNull();
+    expect(requestState?.method).toBe("POST");
+    expect(requestState?.url).toBe("https://api.example.com/v1/users");
+
+    expect(requestState?.headers).toEqual([
+      { key: "Authorization", value: "Bearer token123", enabled: true },
+      { key: "Content-Type", value: "application/json", enabled: true },
+    ]);
+
+    expect(requestState?.queryParams).toEqual([
+      { key: "page", value: "1", enabled: true },
+      { key: "limit", value: "10", enabled: true },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #509.

Importing collections via `postman-import` or `openapi-import` creates request and table blocks using helper functions (`createMethodNode`, `createUrlNode`, `createHeadersTableNode`, etc.). These helpers produce raw ProseMirror node structures (`content: [{ type: 'text', text: '...' }]` and nested `tableRow`/`tableCell` arrays). `convertBlocksToVoidFile` was stringifying these raw nodes directly into YAML inside ```void ... ``` blocks without applying the simplification step.

`voiden-runner`'s headless parser expects the simplified format (`content: "string"` for method/URL nodes, `rows: [{ row: [...] }]` for tables). Because raw structures were saved on import, `voiden-runner` failed to parse `method`, `url`, and tables, causing `buildRequest` to return `null` and throwing:
`No plugin could build a request from the document blocks. Ensure the required plugin (e.g. voiden-rest-api, voiden-graphql) is enabled.`

Opening and saving the file in the desktop UI fixed it because the UI's save serializer runs `simplifyTableNode` and `collapseTextContent`.

## Fix
Added `simplifyBlock` (running `simplifyTableNode` and `collapseTextContent`) directly inside `convertBlocksToVoidFile` in `plugins/voiden-rest-api/src/lib/helpers.ts`. Now, all files generated via `convertBlocksToVoidFile` are automatically saved in the simplified, `voiden-runner`-compatible format upon import. Added unit tests covering import block serialization and `voiden-runner` parsing.

## Verification
- Unit test added in `apps/ui/src/core/editors/voiden/__test__/helpers.test.ts` passing.
- All existing `markdownSerializer.test.ts` tests passing.