### PR TITLE
fix: keep File Explorer highlight in sync with the active file

### DIFF
--- a/apps/ui/src/core/file-system/components/FileSystemList.tsx
+++ b/apps/ui/src/core/file-system/components/FileSystemList.tsx
@@ -612,14 +612,23 @@ export const FileSystemList = () => {
   }, [treeData, tryStartDuplicateRename]);
 
   useEffect(() => {
-    if (!activeFile?.source) return;
+    if (!activeFile?.source) {
+      const tree = treeRef.current;
+      if (!tree) return;
+      const { anchor, mostRecent } = tree.state.nodes.selection;
+      tree.setSelection({ ids: [], anchor, mostRecent });
+      return;
+    }
 
-    const expandAndScroll = async () => {
+    const source = activeFile.source;
+    let cancelled = false;
+
+    const expandAndSelect = async () => {
       const tree = treeRef.current;
       if (!tree) return;
 
       const ancestors: string[] = [];
-      let cursor = getParentPath(activeFile.source);
+      let cursor = getParentPath(source);
       while (cursor) {
         ancestors.unshift(cursor);
         const parent = getParentPath(cursor);
@@ -628,6 +637,7 @@ export const FileSystemList = () => {
       }
 
       for (const ancestorPath of ancestors) {
+        if (cancelled) return;
         const node = tree.get(ancestorPath);
         if (!node) continue;
 
@@ -650,11 +660,16 @@ export const FileSystemList = () => {
       }
 
       setTimeout(() => {
-        treeRef.current?.scrollTo(activeFile.source, "auto");
+        if (cancelled) return;
+        treeRef.current?.select(source, { align: "auto", focus: false });
       }, 50);
     };
 
-    expandAndScroll();
+    expandAndSelect();
+
+    return () => {
+      cancelled = true;
+    };
   }, [activeFile?.source]);
 
   const getInitialOpenState = (root: ExtendedFileTree) => {

--- a/apps/ui/src/core/file-system/components/FileSystemList/TreeNode.tsx
+++ b/apps/ui/src/core/file-system/components/FileSystemList/TreeNode.tsx
@@ -447,6 +447,8 @@ export function TreeNode({
 
   const nameClass = getNameClass(node.data, activeFile);
   const showCollapseAll = node.data.type === "folder" && hasOpenDescendant(node);
+  const isActiveFile = activeFile?.source === node.data.path;
+  const isRangeSelected = node.isSelected && node.tree.selectedNodes.length > 1;
 
   return (
     <div
@@ -454,17 +456,17 @@ export function TreeNode({
       ref={dragHandle}
       className={cn(
         "group h-[22px] overflow-hidden transition-colors border border-transparent",
-        !isDragOver && activeFile?.source !== node.data.path && !node.isSelected && "hover:bg-hover",
+        !isDragOver && !isActiveFile && !node.isSelected && "hover:bg-hover",
         isContextMenuOpen && "border-active",
-        activeFile?.source === node.data.path && !isDragOver && "bg-active",
+        isActiveFile && !isRangeSelected && !isDragOver && "bg-active",
         // Selection stays visible (background) even after focus moves away
         // (e.g. clicking into the editor) — a border is added only while
         // this row is still the actually-focused selection, so the two
         // states ("selected" vs "selected AND focused") read differently,
         // matching Cursor's sidebar.
-        node.isSelected && node.tree.selectedNodes.length <= 1 && activeFile?.source !== node.data.path && !isDragOver && "bg-active",
-        node.isSelected && node.tree.selectedNodes.length <= 1 && node.isFocused && activeFile?.source !== node.data.path && !isDragOver && "border-border",
-        node.isSelected && node.tree.selectedNodes.length > 1 && activeFile?.source !== node.data.path && !isDragOver && "bg-accent/20",
+        node.isSelected && !isRangeSelected && !isActiveFile && !isDragOver && "bg-active",
+        node.isSelected && !isRangeSelected && node.isFocused && !isActiveFile && !isDragOver && "border-border",
+        isRangeSelected && !isDragOver && "bg-accent/20",
         node.isFocused && !isDragOver && "ring-0",
         (isDragOver || isInternalDropTargetFolder) && `bg-accent/30 ${node.data.type === "folder" ? "border-l-2 border-accent" : ""}`,
         isSiblingHighlight && !isDragOver && !isInternalDropTargetFolder && "bg-accent/30 hover:bg-accent/30",


### PR DESCRIPTION
## Problem

Closes #528. In the File Explorer a row's highlight comes from two independent sources — the active document (`activeFile.source`) and react-arborist's own selection (`node.isSelected`, set on click and never cleared). Clicking a file sets both, but every other way of changing the active document leaves the selection stale:

- **Close all tabs** → `activeFile` becomes `null` but the last-clicked row stays selected, so it remains highlighted.
- **Switch tabs from the tab bar** → `activeFile` moves while the tree selection stays on the last-clicked file, so two rows are highlighted at once.

## Fix

Drive the tree selection from the active document in the existing `activeFile?.source` effect (`apps/ui/src/core/file-system/components/FileSystemList.tsx`):

- No active document → `deselectAll()`, so no row stays highlighted.
- Active document → `select(source, { focus: false })` (replacing the bare `scrollTo`), which clears any previous selection and scrolls the row into view, so exactly one row — the active file — is lit. `focus: false` keeps it a purely visual sync, and a `cancelled` guard avoids a stale select during rapid tab switches.

## Testing

- Verified manually in the running app: closing all tabs clears the highlight, and switching tabs never leaves two rows highlighted.
- `yarn typecheck` (apps/ui): no new type errors from this change.