### PR TITLE
fix: size request name input to its content

### DIFF
--- a/apps/ui/src/core/editors/voiden/__test__/requestSeparatorNode.test.ts
+++ b/apps/ui/src/core/editors/voiden/__test__/requestSeparatorNode.test.ts
@@ -1,0 +1,75 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tiptap/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tiptap/react")>();
+
+  return {
+    ...actual,
+    NodeViewWrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+  };
+});
+
+vi.mock("@/core/settings/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: { appearance: { separator_alignment: "center" } },
+  }),
+}));
+
+vi.mock("@/core/editors/voiden/extensions/sectionIndicator", () => ({
+  getSectionLineColor: () => "#999",
+}));
+
+import { RequestSeparatorView } from "../nodes/RequestSeparatorNode";
+
+const createProps = (label: string): NodeViewProps =>
+  ({
+    node: { attrs: { uid: "request-1", colorIndex: 0, label } },
+    editor: { isEditable: true },
+    updateAttributes: vi.fn(),
+  }) as unknown as NodeViewProps;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RequestSeparatorView", () => {
+  it("sizes the rename input to its content without shrinking below the default width", async () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const width =
+          this.getAttribute("aria-hidden") === "true"
+            ? (this.textContent?.length ?? 0) * 10 + 18
+            : 0;
+
+        return {
+          x: 0,
+          y: 0,
+          width,
+          height: 0,
+          top: 0,
+          right: width,
+          bottom: 0,
+          left: 0,
+          toJSON: () => {},
+        };
+      },
+    );
+
+    const label = "CleanupDeleteCalendarEntryNotificationsUser1";
+    render(React.createElement(RequestSeparatorView, createProps(label)));
+
+    fireEvent.doubleClick(screen.getByText(label));
+
+    const input = await screen.findByRole("textbox");
+    await waitFor(() =>
+      expect(input.style.width).toBe(`${label.length * 10 + 18}px`),
+    );
+
+    fireEvent.change(input, { target: { value: "GET" } });
+    await waitFor(() => expect(input.style.width).toBe("80px"));
+  });
+});

--- a/apps/ui/src/core/editors/voiden/nodes/RequestSeparatorNode.tsx
+++ b/apps/ui/src/core/editors/voiden/nodes/RequestSeparatorNode.tsx
@@ -8,16 +8,31 @@
 
 import { Node, mergeAttributes } from "@tiptap/core";
 import { NodeViewProps, ReactNodeViewRenderer, NodeViewWrapper } from "@tiptap/react";
-import { useRef, useState, useEffect, useCallback } from "react";
+import { useRef, useState, useEffect, useLayoutEffect, useCallback } from "react";
 import { getSectionLineColor } from "../extensions/sectionIndicator";
 import { useSettings } from "@/core/settings/hooks/useSettings";
 
-const RequestSeparatorView = (props: NodeViewProps) => {
+const REQUEST_NAME_INPUT_MIN_WIDTH = 80;
+
+const requestNameInputTextStyle: React.CSSProperties = {
+  fontSize: "10px",
+  fontWeight: 700,
+  letterSpacing: "1.5px",
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+  padding: "2px 8px",
+  boxSizing: "border-box",
+  fontFamily: "inherit",
+};
+
+export const RequestSeparatorView = (props: NodeViewProps) => {
   const { node, updateAttributes, editor } = props;
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputSizerRef = useRef<HTMLSpanElement>(null);
   const [decorationColor, setDecorationColor] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState("");
+  const [inputWidth, setInputWidth] = useState(REQUEST_NAME_INPUT_MIN_WIDTH);
   const inputRef = useRef<HTMLInputElement>(null);
   const { settings } = useSettings();
   const alignment = settings?.appearance?.separator_alignment ?? "center";
@@ -54,9 +69,19 @@ const RequestSeparatorView = (props: NodeViewProps) => {
   const textColor = decorationColor ?? getSectionLineColor(colorIndex);
   const label = node.attrs.label || "New Request";
 
+  useLayoutEffect(() => {
+    if (!isEditing || !inputSizerRef.current) return;
+
+    const measuredWidth = Math.ceil(
+      inputSizerRef.current.getBoundingClientRect().width,
+    );
+    setInputWidth(Math.max(REQUEST_NAME_INPUT_MIN_WIDTH, measuredWidth));
+  }, [editValue, isEditing]);
+
   const startEditing = useCallback(() => {
     if (!editor.isEditable) return;
     setEditValue(label === "New Request" ? "" : label);
+    setInputWidth(REQUEST_NAME_INPUT_MIN_WIDTH);
     setIsEditing(true);
     setTimeout(() => inputRef.current?.focus(), 0);
   }, [label, editor.isEditable]);
@@ -93,42 +118,52 @@ const RequestSeparatorView = (props: NodeViewProps) => {
           }}
         />
         {isEditing ? (
-          <input
-            ref={inputRef}
-            type="text"
-            value={editValue}
-            placeholder="New Request"
-            onChange={(e) => setEditValue(e.target.value)}
-            onBlur={commitEdit}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                commitEdit();
-              }
-              if (e.key === "Escape") {
-                setIsEditing(false);
-              }
-              // Prevent ProseMirror from handling these keys
-              e.stopPropagation();
-            }}
-            style={{
-              fontSize: "10px",
-              fontWeight: 700,
-              letterSpacing: "1.5px",
-              textTransform: "uppercase",
-              color: textColor,
-              whiteSpace: "nowrap",
-              background: "var(--editor-bg, transparent)",
-              border: `1px solid ${lineColor}`,
-              borderRadius: "3px",
-              padding: "2px 8px",
-              outline: "none",
-              textAlign: "center",
-              minWidth: "80px",
-              maxWidth: "200px",
-              fontFamily: "inherit",
-            }}
-          />
+          <>
+            <span
+              ref={inputSizerRef}
+              aria-hidden="true"
+              style={{
+                ...requestNameInputTextStyle,
+                position: "absolute",
+                visibility: "hidden",
+                pointerEvents: "none",
+                border: "1px solid transparent",
+              }}
+            >
+              {editValue || "New Request"}
+            </span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={editValue}
+              placeholder="New Request"
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitEdit();
+                }
+                if (e.key === "Escape") {
+                  setIsEditing(false);
+                }
+                // Prevent ProseMirror from handling these keys
+                e.stopPropagation();
+              }}
+              style={{
+                ...requestNameInputTextStyle,
+                color: textColor,
+                background: "var(--editor-bg, transparent)",
+                border: `1px solid ${lineColor}`,
+                borderRadius: "3px",
+                outline: "none",
+                textAlign: "center",
+                width: `${inputWidth}px`,
+                minWidth: `${REQUEST_NAME_INPUT_MIN_WIDTH}px`,
+                maxWidth: "calc(100% - 64px)",
+              }}
+            />
+          </>
         ) : (
           <span
             onDoubleClick={startEditing}


### PR DESCRIPTION
## Summary

- Size the request-name edit input from its rendered label instead of capping it at 200px.
- Preserve the existing 80px minimum width and constrain the input to the available request row.
- Cover long and short request names with a focused regression test.

## Why

Long request names were truncated while being edited, making them difficult to review and update.

Fixes #532

## Validation

- `corepack yarn workspace voiden-ui test --run src/core/editors/voiden/__test__/requestSeparatorNode.test.ts`
- `corepack yarn workspace voiden build:nix`
- Manual UI verification with a long request name, a short request name, and a reopen check.
