### PR TITLE
feat(plugin): JWT Faker for generating test JWTs

### DIFF
--- a/plugins/jwt-faker/README.md
+++ b/plugins/jwt-faker/README.md
@@ -1,0 +1,11 @@
+# JWT Faker Plugin for Voiden
+
+Generate, customize, sign, decode, and copy JSON Web Tokens (JWTs) directly inside Voiden for API authentication testing.
+
+## Features
+- Signing algorithms: `HS256`, `HS384`, `HS512`, `none` (unsigned)
+- Custom JSON payload & header editors
+- Claim quick-buttons for `exp` (expiration), `iat` (issued-at), `nbf` (not-before)
+- Live preview of decoded token parts
+- One-click copy token to clipboard
+- Save & load reusable templates

--- a/plugins/jwt-faker/dist/jwt-faker.js
+++ b/plugins/jwt-faker/dist/jwt-faker.js
@@ -81,9 +81,9 @@ async function K(a, d, t) {
 }
 async function q(a, d, t, n = "HS256") {
   const s = {
-    alg: n,
     typ: "JWT",
-    ...a
+    ...a,
+    alg: n
   }, i = H(JSON.stringify(s)), c = H(JSON.stringify(d)), l = `${i}.${c}`;
   if (n === "none")
     return `${l}.`;

--- a/plugins/jwt-faker/dist/jwt-faker.js
+++ b/plugins/jwt-faker/dist/jwt-faker.js
@@ -81,8 +81,8 @@ async function K(a, d, t) {
 }
 async function q(a, d, t, n = "HS256") {
   const s = {
-    typ: "JWT",
     ...a,
+    typ: a.typ || "JWT",
     alg: n
   }, i = H(JSON.stringify(s)), c = H(JSON.stringify(d)), l = `${i}.${c}`;
   if (n === "none")

--- a/plugins/jwt-faker/dist/jwt-faker.js
+++ b/plugins/jwt-faker/dist/jwt-faker.js
@@ -1,0 +1,523 @@
+const oe = 2, ae = { id: "jwt-faker", name: "JWT Faker", description: "Generate, customize, sign, decode, and copy JSON Web Tokens (JWTs) directly within Voiden for testing authenticated APIs with support for HS256, HS384, HS512, and unsigned tokens.", version: "1.0.0", voidenVersion: ">=2.0.0", author: "Voiden Team", enabled: !0, priority: 50, readme: "Generate and decode JWTs for testing authenticated APIs. Supports HS256, HS384, HS512, unsigned tokens (alg: none), custom payload/header editors, expiration/issued-at claim helpers, template saving, and one-click copy.", capabilities: { ui: { buttons: [{ id: "jwt-faker-btn", location: "sidebar-left", icon: "Sparkles", tooltip: "JWT Faker", description: "Opens JWT Faker dialog to generate and decode test JWTs" }], description: "Adds JWT Faker generator to UI toolbar and editor actions" } }, dependencies: { core: "^1.0.0", sdk: "^1.0.0" }, features: ["Generate JWTs using HMAC SHA algorithms: HS256, HS384, HS512", "Generate unsigned tokens (alg: none) for testing", "Custom JSON payload editor with validation", "Custom JSON header editor", "Quick claim helpers for exp (expiration), iat (issued-at), nbf (not-before)", "Live preview of encoded and decoded JWT components (Header, Payload, Signature)", "One-click copy of generated JWT token string", "Save and manage reusable JWT claim templates"] }, L = window.__voiden_shims__.react, {
+  useState: u,
+  useEffect: j,
+  useCallback: de,
+  useMemo: ie,
+  useRef: se,
+  useContext: le,
+  createContext: ce,
+  forwardRef: ue,
+  memo: me,
+  Fragment: pe,
+  createElement: ge,
+  cloneElement: fe,
+  Children: be,
+  StrictMode: he,
+  Suspense: xe,
+  lazy: ye,
+  isValidElement: ve,
+  Component: we,
+  PureComponent: Ne,
+  createRef: Se,
+  startTransition: ke,
+  useReducer: Ce,
+  useLayoutEffect: _e,
+  useImperativeHandle: Je,
+  useDebugValue: He,
+  useTransition: Te,
+  useDeferredValue: Ae,
+  useId: Oe
+} = L, T = window.__voiden_shims__["react/jsx-runtime"], e = T.jsx, o = T.jsxs, z = T.Fragment;
+function H(a) {
+  let d = "";
+  if (typeof a == "string") {
+    const n = new TextEncoder().encode(a);
+    let s = "";
+    for (let i = 0; i < n.byteLength; i++)
+      s += String.fromCharCode(n[i]);
+    d = btoa(s);
+  } else {
+    let t = "";
+    for (let n = 0; n < a.byteLength; n++)
+      t += String.fromCharCode(a[n]);
+    d = btoa(t);
+  }
+  return d.replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+function P(a) {
+  let d = a.replace(/-/g, "+").replace(/_/g, "/");
+  for (; d.length % 4 !== 0; )
+    d += "=";
+  const t = atob(d), n = new Uint8Array(t.length);
+  for (let i = 0; i < t.length; i++)
+    n[i] = t.charCodeAt(i);
+  return new TextDecoder().decode(n);
+}
+function B(a) {
+  switch (a) {
+    case "HS256":
+      return "SHA-256";
+    case "HS384":
+      return "SHA-384";
+    case "HS512":
+      return "SHA-512";
+    default:
+      throw new Error(`Unsupported HMAC algorithm: ${a}`);
+  }
+}
+async function K(a, d, t) {
+  const n = B(a), s = new TextEncoder(), i = s.encode(d), c = await crypto.subtle.importKey(
+    "raw",
+    i,
+    { name: "HMAC", hash: { name: n } },
+    !1,
+    ["sign"]
+  ), l = await crypto.subtle.sign(
+    "HMAC",
+    c,
+    s.encode(t)
+  );
+  return H(new Uint8Array(l));
+}
+async function q(a, d, t, n = "HS256") {
+  const s = {
+    alg: n,
+    typ: "JWT",
+    ...a
+  }, i = H(JSON.stringify(s)), c = H(JSON.stringify(d)), l = `${i}.${c}`;
+  if (n === "none")
+    return `${l}.`;
+  if (!t)
+    throw new Error(`Secret key is required for ${n} signing`);
+  const h = await K(n, t, l);
+  return `${l}.${h}`;
+}
+function X(a) {
+  if (!a || typeof a != "string")
+    return {
+      header: { alg: "none", typ: "JWT" },
+      payload: {},
+      signature: "",
+      rawHeader: "",
+      rawPayload: "",
+      isValid: !1,
+      error: "Token string is empty"
+    };
+  const d = a.trim().split(".");
+  if (d.length < 2 || d.length > 3)
+    return {
+      header: { alg: "none", typ: "JWT" },
+      payload: {},
+      signature: "",
+      rawHeader: "",
+      rawPayload: "",
+      isValid: !1,
+      error: "Invalid JWT format: must contain header, payload, and signature sections"
+    };
+  try {
+    const t = P(d[0]), n = P(d[1]), s = d[2] || "", i = JSON.parse(t), c = JSON.parse(n);
+    return {
+      header: i,
+      payload: c,
+      signature: s,
+      rawHeader: t,
+      rawPayload: n,
+      isValid: !0
+    };
+  } catch (t) {
+    const n = t instanceof Error ? t.message : String(t);
+    return {
+      header: { alg: "none", typ: "JWT" },
+      payload: {},
+      signature: d[2] || "",
+      rawHeader: d[0] || "",
+      rawPayload: d[1] || "",
+      isValid: !1,
+      error: `Failed to decode JWT: ${n}`
+    };
+  }
+}
+function C(a = 0) {
+  return Math.floor(Date.now() / 1e3) + a;
+}
+const Q = window.__voiden_shims__["lucide-react"] || {}, { AlertCircle: De, ArrowDown: We, ArrowDownLeft: Ee, ArrowLeft: Fe, ArrowLeftRight: je, ArrowRight: Pe, ArrowUp: Re, ArrowUpRight: Le, BookOpen: Ie, Check: Y, CheckCheck: Me, ChevronDown: $e, ChevronRight: Ue, ChevronsDownUp: Ve, ChevronsUpDown: Ge, Circle: ze, CircleAlert: Be, CircleX: Ke, Clock: qe, Columns2: Xe, Copy: Z, CornerDownLeft: Qe, CornerDownRight: Ye, Download: Ze, ExternalLink: et, Eye: tt, FileDown: rt, FileText: nt, Folder: ot, FolderOpen: at, History: dt, Info: it, Link: st, Loader: lt, Loader2: ct, Mouse: ut, Pen: mt, Pencil: pt, Play: gt, Plus: ft, Radio: bt, RefreshCw: ht, Rows: xt, Search: yt, SkipForward: vt, Sparkles: ee, Square: wt, Trash2: Nt, Unlink: St, Wifi: kt, WifiOff: Ct, WrapText: _t, X: R, XCircle: Jt } = Q, te = JSON.stringify({ alg: "HS256", typ: "JWT" }, null, 2), re = JSON.stringify(
+  {
+    sub: "123456789",
+    name: "John Doe",
+    email: "john@example.com",
+    role: "admin",
+    iat: Math.floor(Date.now() / 1e3),
+    exp: Math.floor(Date.now() / 1e3) + 3600
+  },
+  null,
+  2
+), ne = ({ isOpen: a, onClose: d, showToast: t }) => {
+  const [n, s] = u("HS256"), [i, c] = u("your-256-bit-secret"), [l, h] = u(te), [b, _] = u(re), [p, I] = u(""), [A, O] = u(!1), [g, x] = u("editor"), [J, D] = u(""), [W, y] = u(null), [f, E] = u(() => {
+    try {
+      const r = localStorage.getItem("__voiden_jwt_templates__");
+      return r ? JSON.parse(r) : [];
+    } catch {
+      return [];
+    }
+  }), [v, F] = u("");
+  if (j(() => {
+    try {
+      localStorage.setItem("__voiden_jwt_templates__", JSON.stringify(f));
+    } catch {
+    }
+  }, [f]), j(() => {
+    let r = !0;
+    return (async () => {
+      try {
+        y(null);
+        let m = {}, k = {};
+        try {
+          m = JSON.parse(l);
+        } catch {
+          y("Invalid JSON in Header");
+          return;
+        }
+        try {
+          k = JSON.parse(b);
+        } catch {
+          y("Invalid JSON in Payload");
+          return;
+        }
+        const G = await q(m, k, i, n);
+        r && I(G);
+      } catch (m) {
+        if (r) {
+          const k = m instanceof Error ? m.message : String(m);
+          y(k);
+        }
+      }
+    })(), () => {
+      r = !1;
+    };
+  }, [n, i, l, b]), !a) return null;
+  const M = () => {
+    p && (navigator.clipboard.writeText(p), O(!0), t == null || t("JWT copied to clipboard!", "success"), setTimeout(() => O(!1), 2e3));
+  }, w = (r, S) => {
+    try {
+      const m = JSON.parse(b || "{}");
+      m[r] = S, _(JSON.stringify(m, null, 2));
+    } catch {
+    }
+  }, $ = () => {
+    if (!v.trim()) return;
+    const r = {
+      id: Date.now().toString(),
+      name: v.trim(),
+      algorithm: n,
+      secret: i,
+      header: l,
+      payload: b
+    };
+    E([...f, r]), F(""), t == null || t(`Saved template "${r.name}"`, "success");
+  }, U = (r) => {
+    s(r.algorithm), c(r.secret), h(r.header), _(r.payload), x("editor"), t == null || t(`Loaded template "${r.name}"`, "info");
+  }, V = (r) => {
+    E(f.filter((S) => S.id !== r));
+  }, N = X(g === "decoder" && J || p);
+  return /* @__PURE__ */ e("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4", children: /* @__PURE__ */ o("div", { className: "bg-panel border border-border rounded-lg shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col text-foreground overflow-hidden", children: [
+    /* @__PURE__ */ o("div", { className: "flex items-center justify-between px-4 py-3 border-b border-border bg-muted/20", children: [
+      /* @__PURE__ */ o("div", { className: "flex items-center gap-2", children: [
+        /* @__PURE__ */ e(ee, { className: "w-5 h-5 text-yellow-500" }),
+        /* @__PURE__ */ e("h2", { className: "text-base font-semibold", children: "JWT Faker & Generator" })
+      ] }),
+      /* @__PURE__ */ o("div", { className: "flex items-center gap-2", children: [
+        /* @__PURE__ */ o("div", { className: "flex bg-muted/40 rounded p-0.5 text-xs", children: [
+          /* @__PURE__ */ e(
+            "button",
+            {
+              className: `px-3 py-1 rounded transition-colors ${g === "editor" ? "bg-primary text-primary-foreground font-medium" : "text-muted hover:text-foreground"}`,
+              onClick: () => x("editor"),
+              children: "Generator"
+            }
+          ),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              className: `px-3 py-1 rounded transition-colors ${g === "decoder" ? "bg-primary text-primary-foreground font-medium" : "text-muted hover:text-foreground"}`,
+              onClick: () => {
+                x("decoder"), J || D(p);
+              },
+              children: "Decoder"
+            }
+          ),
+          /* @__PURE__ */ o(
+            "button",
+            {
+              className: `px-3 py-1 rounded transition-colors ${g === "templates" ? "bg-primary text-primary-foreground font-medium" : "text-muted hover:text-foreground"}`,
+              onClick: () => x("templates"),
+              children: [
+                "Templates (",
+                f.length,
+                ")"
+              ]
+            }
+          )
+        ] }),
+        /* @__PURE__ */ e("button", { onClick: d, className: "p-1 text-muted hover:text-foreground rounded", children: /* @__PURE__ */ e(R, { size: 18 }) })
+      ] })
+    ] }),
+    /* @__PURE__ */ o("div", { className: "flex-1 overflow-y-auto p-4 space-y-4", children: [
+      g === "editor" && /* @__PURE__ */ o(z, { children: [
+        /* @__PURE__ */ o("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-4", children: [
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ e("label", { className: "block text-xs font-medium text-muted mb-1", children: "Algorithm" }),
+            /* @__PURE__ */ o(
+              "select",
+              {
+                value: n,
+                onChange: (r) => s(r.target.value),
+                className: "w-full bg-input border border-border rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-primary",
+                children: [
+                  /* @__PURE__ */ e("option", { value: "HS256", children: "HS256 (HMAC SHA-256)" }),
+                  /* @__PURE__ */ e("option", { value: "HS384", children: "HS384 (HMAC SHA-384)" }),
+                  /* @__PURE__ */ e("option", { value: "HS512", children: "HS512 (HMAC SHA-512)" }),
+                  /* @__PURE__ */ e("option", { value: "none", children: "none (Unsigned Token)" })
+                ]
+              }
+            )
+          ] }),
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ o("label", { className: "block text-xs font-medium text-muted mb-1", children: [
+              "Secret Key ",
+              n === "none" && "(Not required for unsigned)"
+            ] }),
+            /* @__PURE__ */ e(
+              "input",
+              {
+                type: "text",
+                value: i,
+                onChange: (r) => c(r.target.value),
+                disabled: n === "none",
+                placeholder: "Enter signing secret",
+                className: "w-full bg-input border border-border rounded px-2.5 py-1.5 text-sm disabled:opacity-50 focus:ring-1 focus:ring-primary"
+              }
+            )
+          ] })
+        ] }),
+        /* @__PURE__ */ o("div", { className: "flex flex-wrap items-center gap-2 text-xs", children: [
+          /* @__PURE__ */ e("span", { className: "text-muted font-medium", children: "Quick Claims:" }),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              onClick: () => w("exp", C(3600)),
+              className: "px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors",
+              children: "+1h Exp"
+            }
+          ),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              onClick: () => w("exp", C(86400)),
+              className: "px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors",
+              children: "+1d Exp"
+            }
+          ),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              onClick: () => w("iat", C(0)),
+              className: "px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors",
+              children: "Set iat Now"
+            }
+          ),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              onClick: () => w("nbf", C(0)),
+              className: "px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors",
+              children: "Set nbf Now"
+            }
+          )
+        ] }),
+        /* @__PURE__ */ o("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-4", children: [
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ e("div", { className: "flex items-center justify-between mb-1", children: /* @__PURE__ */ e("label", { className: "text-xs font-medium text-muted", children: "Header (JSON)" }) }),
+            /* @__PURE__ */ e(
+              "textarea",
+              {
+                rows: 6,
+                value: l,
+                onChange: (r) => h(r.target.value),
+                className: "w-full font-mono text-xs bg-input border border-border rounded p-2 focus:ring-1 focus:ring-primary"
+              }
+            )
+          ] }),
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ e("div", { className: "flex items-center justify-between mb-1", children: /* @__PURE__ */ e("label", { className: "text-xs font-medium text-muted", children: "Payload (JSON)" }) }),
+            /* @__PURE__ */ e(
+              "textarea",
+              {
+                rows: 6,
+                value: b,
+                onChange: (r) => _(r.target.value),
+                className: "w-full font-mono text-xs bg-input border border-border rounded p-2 focus:ring-1 focus:ring-primary"
+              }
+            )
+          ] })
+        ] }),
+        W && /* @__PURE__ */ e("div", { className: "text-xs text-red-500 bg-red-500/10 border border-red-500/30 rounded px-2.5 py-1.5", children: W }),
+        /* @__PURE__ */ o("div", { children: [
+          /* @__PURE__ */ o("div", { className: "flex items-center justify-between mb-1", children: [
+            /* @__PURE__ */ e("label", { className: "text-xs font-semibold text-foreground", children: "Generated Encoded JWT" }),
+            /* @__PURE__ */ o(
+              "button",
+              {
+                onClick: M,
+                disabled: !p,
+                className: "flex items-center gap-1.5 px-2.5 py-1 text-xs bg-primary hover:bg-primary/90 text-primary-foreground font-medium rounded transition-colors",
+                children: [
+                  A ? /* @__PURE__ */ e(Y, { size: 14 }) : /* @__PURE__ */ e(Z, { size: 14 }),
+                  A ? "Copied!" : "Copy JWT"
+                ]
+              }
+            )
+          ] }),
+          /* @__PURE__ */ e(
+            "textarea",
+            {
+              readOnly: !0,
+              rows: 3,
+              value: p,
+              className: "w-full font-mono text-xs bg-muted/20 border border-border rounded p-2 text-yellow-500 select-all"
+            }
+          )
+        ] }),
+        /* @__PURE__ */ o("div", { className: "flex items-center gap-2 pt-2 border-t border-border", children: [
+          /* @__PURE__ */ e(
+            "input",
+            {
+              type: "text",
+              placeholder: "Template name (e.g. Admin Token)",
+              value: v,
+              onChange: (r) => F(r.target.value),
+              className: "flex-1 bg-input border border-border rounded px-2.5 py-1 text-xs"
+            }
+          ),
+          /* @__PURE__ */ e(
+            "button",
+            {
+              onClick: $,
+              disabled: !v.trim(),
+              className: "px-3 py-1 bg-muted hover:bg-muted/80 text-xs font-medium rounded transition-colors disabled:opacity-50",
+              children: "Save as Template"
+            }
+          )
+        ] })
+      ] }),
+      g === "decoder" && /* @__PURE__ */ o("div", { className: "space-y-4", children: [
+        /* @__PURE__ */ o("div", { children: [
+          /* @__PURE__ */ e("label", { className: "block text-xs font-medium text-muted mb-1", children: "JWT Token to Decode" }),
+          /* @__PURE__ */ e(
+            "textarea",
+            {
+              rows: 3,
+              value: J,
+              onChange: (r) => D(r.target.value),
+              placeholder: "Paste JWT token here...",
+              className: "w-full font-mono text-xs bg-input border border-border rounded p-2"
+            }
+          )
+        ] }),
+        N.isValid ? /* @__PURE__ */ o("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-4", children: [
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ e("span", { className: "block text-xs font-semibold text-red-400 mb-1", children: "Decoded Header" }),
+            /* @__PURE__ */ e("pre", { className: "font-mono text-xs bg-muted/20 border border-border rounded p-2 overflow-x-auto text-red-400", children: JSON.stringify(N.header, null, 2) })
+          ] }),
+          /* @__PURE__ */ o("div", { children: [
+            /* @__PURE__ */ e("span", { className: "block text-xs font-semibold text-purple-400 mb-1", children: "Decoded Payload" }),
+            /* @__PURE__ */ e("pre", { className: "font-mono text-xs bg-muted/20 border border-border rounded p-2 overflow-x-auto text-purple-400", children: JSON.stringify(N.payload, null, 2) })
+          ] })
+        ] }) : /* @__PURE__ */ e("div", { className: "text-xs text-red-500 bg-red-500/10 border border-red-500/30 rounded p-2", children: N.error || "Invalid token structure" })
+      ] }),
+      g === "templates" && /* @__PURE__ */ e("div", { className: "space-y-3", children: f.length === 0 ? /* @__PURE__ */ e("div", { className: "text-xs text-muted text-center py-6", children: 'No saved templates yet. Customize claims in the Generator and click "Save as Template".' }) : f.map((r) => /* @__PURE__ */ o(
+        "div",
+        {
+          className: "flex items-center justify-between p-2.5 border border-border rounded bg-muted/10 hover:bg-muted/20",
+          children: [
+            /* @__PURE__ */ o("div", { children: [
+              /* @__PURE__ */ e("div", { className: "text-xs font-semibold text-foreground", children: r.name }),
+              /* @__PURE__ */ o("div", { className: "text-[11px] text-muted", children: [
+                "Alg: ",
+                r.algorithm,
+                " | Key: ",
+                r.secret || "(none)"
+              ] })
+            ] }),
+            /* @__PURE__ */ o("div", { className: "flex items-center gap-2", children: [
+              /* @__PURE__ */ e(
+                "button",
+                {
+                  onClick: () => U(r),
+                  className: "px-2.5 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90",
+                  children: "Load"
+                }
+              ),
+              /* @__PURE__ */ e(
+                "button",
+                {
+                  onClick: () => V(r.id),
+                  className: "p-1 text-muted hover:text-red-500",
+                  children: /* @__PURE__ */ e(R, { size: 14 })
+                }
+              )
+            ] })
+          ]
+        },
+        r.id
+      )) })
+    ] })
+  ] }) });
+}, Ht = (a) => {
+  var i;
+  const d = (i = a == null ? void 0 : a.ui) == null ? void 0 : i.showToast;
+  let t = null, n = !1;
+  const s = () => {
+    var l;
+    t || (t = document.createElement("div"), t.id = "jwt-faker-modal-root", document.body.appendChild(t));
+    const { createRoot: c } = ((l = window.__voiden_shims__) == null ? void 0 : l["react-dom/client"]) || {};
+    c && (t._reactRoot || (t._reactRoot = c(t)), t._reactRoot.render(
+      L.createElement(ne, {
+        isOpen: n,
+        onClose: () => {
+          n = !1, s();
+        },
+        showToast: d
+      })
+    ));
+  };
+  return {
+    onload: () => {
+      window.__voidenOpenJwtFaker__ = () => {
+        n = !0, s();
+      }, typeof a.registerStatusBarItem == "function" && a.registerStatusBarItem({
+        id: "jwt-faker-status-item",
+        text: "JWT Faker",
+        icon: "Sparkles",
+        tooltip: "Generate and decode JWT tokens for testing",
+        onClick: () => {
+          n = !0, s();
+        }
+      });
+    },
+    onunload: () => {
+      delete window.__voidenOpenJwtFaker__, t && (t._reactRoot && t._reactRoot.unmount(), t.remove(), t = null);
+    }
+  };
+};
+export {
+  ne as JwtFakerModal,
+  oe as __voiden_bundle_version__,
+  ae as __voiden_manifest__,
+  P as base64urlDecode,
+  H as base64urlEncode,
+  X as decodeJwt,
+  Ht as default,
+  q as generateJwt,
+  C as getClaimTimestamp,
+  K as signHmac
+};

--- a/plugins/jwt-faker/manifest.json
+++ b/plugins/jwt-faker/manifest.json
@@ -1,0 +1,42 @@
+{
+  "id": "jwt-faker",
+  "name": "JWT Faker",
+  "description": "Generate, customize, sign, decode, and copy JSON Web Tokens (JWTs) directly within Voiden for testing authenticated APIs with support for HS256, HS384, HS512, and unsigned tokens.",
+  "version": "1.0.0",
+  "voidenVersion": ">=2.0.0",
+  "author": "Voiden Team",
+  "enabled": true,
+  "priority": 50,
+  "readme": "Generate and decode JWTs for testing authenticated APIs. Supports HS256, HS384, HS512, unsigned tokens (alg: none), custom payload/header editors, expiration/issued-at claim helpers, template saving, and one-click copy.",
+
+  "capabilities": {
+    "ui": {
+      "buttons": [
+        {
+          "id": "jwt-faker-btn",
+          "location": "sidebar-left",
+          "icon": "Sparkles",
+          "tooltip": "JWT Faker",
+          "description": "Opens JWT Faker dialog to generate and decode test JWTs"
+        }
+      ],
+      "description": "Adds JWT Faker generator to UI toolbar and editor actions"
+    }
+  },
+
+  "dependencies": {
+    "core": "^1.0.0",
+    "sdk": "^1.0.0"
+  },
+
+  "features": [
+    "Generate JWTs using HMAC SHA algorithms: HS256, HS384, HS512",
+    "Generate unsigned tokens (alg: none) for testing",
+    "Custom JSON payload editor with validation",
+    "Custom JSON header editor",
+    "Quick claim helpers for exp (expiration), iat (issued-at), nbf (not-before)",
+    "Live preview of encoded and decoded JWT components (Header, Payload, Signature)",
+    "One-click copy of generated JWT token string",
+    "Save and manage reusable JWT claim templates"
+  ]
+}

--- a/plugins/jwt-faker/package.json
+++ b/plugins/jwt-faker/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@voiden/plugin-jwt-faker",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "node ../../scripts/build-plugins.mjs jwt-faker"
+  },
+  "peerDependencies": {
+    "@voiden/sdk": "^1.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@voiden/sdk": "^1.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/plugins/jwt-faker/src/__tests__/e2e.test.ts
+++ b/plugins/jwt-faker/src/__tests__/e2e.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { generateJwt, decodeJwt, getClaimTimestamp } from '../utils/jwtUtils';
+
+describe('JWT Faker End-to-End Test Suite', () => {
+  const secret = 'super-secret-passphrase-key';
+  const customHeader = { alg: 'HS256', typ: 'JWT', custom_header_key: 'test_val' };
+  const customPayload = {
+    sub: '123456789',
+    email: 'john@example.com',
+    role: 'admin',
+    iat: getClaimTimestamp(0),
+    exp: getClaimTimestamp(3600),
+  };
+
+  it('e2e: generates and decodes HS256 signed token with full claims', async () => {
+    const token = await generateJwt(customHeader, customPayload, secret, 'HS256');
+    expect(token).toBeDefined();
+    expect(typeof token).toBe('string');
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS256');
+    expect(decoded.header.typ).toBe('JWT');
+    expect(decoded.header.custom_header_key).toBe('test_val');
+    expect(decoded.payload.sub).toBe('123456789');
+    expect(decoded.payload.email).toBe('john@example.com');
+    expect(decoded.payload.role).toBe('admin');
+    expect(decoded.payload.exp).toBeGreaterThan(decoded.payload.iat!);
+  });
+
+  it('e2e: generates and decodes HS384 signed token', async () => {
+    const token = await generateJwt(customHeader, customPayload, secret, 'HS384');
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS384');
+  });
+
+  it('e2e: generates and decodes HS512 signed token', async () => {
+    const token = await generateJwt(customHeader, customPayload, secret, 'HS512');
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS512');
+  });
+
+  it('e2e: generates and decodes unsigned (alg: none) token', async () => {
+    const token = await generateJwt({ alg: 'none', typ: 'JWT' }, customPayload, '', 'none');
+    expect(token.endsWith('.')).toBe(true);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('none');
+    expect(decoded.signature).toBe('');
+  });
+});

--- a/plugins/jwt-faker/src/__tests__/e2e.test.ts
+++ b/plugins/jwt-faker/src/__tests__/e2e.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { generateJwt, decodeJwt, getClaimTimestamp } from '../utils/jwtUtils';
+import type { JwtHeader } from '../utils/types';
 
 describe('JWT Faker End-to-End Test Suite', () => {
   const secret = 'super-secret-passphrase-key';
-  const customHeader = { alg: 'HS256', typ: 'JWT', custom_header_key: 'test_val' };
+  const customHeader: JwtHeader = { alg: 'HS256', typ: 'JWT', custom_header_key: 'test_val' };
   const customPayload = {
     sub: '123456789',
     email: 'john@example.com',

--- a/plugins/jwt-faker/src/__tests__/jwtUtils.test.ts
+++ b/plugins/jwt-faker/src/__tests__/jwtUtils.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  base64urlEncode,
+  base64urlDecode,
+  generateJwt,
+  decodeJwt,
+  getClaimTimestamp,
+} from '../utils/jwtUtils';
+
+describe('JWT Faker - Base64Url Utilities', () => {
+  it('encodes and decodes strings to base64url', () => {
+    const input = 'Hello World! @Voiden/JWT-Faker';
+    const encoded = base64urlEncode(input);
+    expect(encoded).not.toContain('=');
+    expect(encoded).not.toContain('+');
+    expect(encoded).not.toContain('/');
+
+    const decoded = base64urlDecode(encoded);
+    expect(decoded).toBe(input);
+  });
+});
+
+describe('JWT Faker - Token Generation (HS256, HS384, HS512, none)', () => {
+  const secret = 'super-secret-key-1234567890';
+  const payload = {
+    sub: 'user_123',
+    email: 'dev@voiden.io',
+    role: 'admin',
+  };
+
+  it('generates a valid HS256 signed JWT token', async () => {
+    const token = await generateJwt({ alg: 'HS256', typ: 'JWT' }, payload, secret, 'HS256');
+    const parts = token.split('.');
+    expect(parts.length).toBe(3);
+    expect(parts[0].length).toBeGreaterThan(0);
+    expect(parts[1].length).toBeGreaterThan(0);
+    expect(parts[2].length).toBeGreaterThan(0);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS256');
+    expect(decoded.payload.sub).toBe('user_123');
+    expect(decoded.payload.email).toBe('dev@voiden.io');
+    expect(decoded.payload.role).toBe('admin');
+  });
+
+  it('generates a valid HS384 signed JWT token', async () => {
+    const token = await generateJwt({ alg: 'HS384', typ: 'JWT' }, payload, secret, 'HS384');
+    const parts = token.split('.');
+    expect(parts.length).toBe(3);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS384');
+  });
+
+  it('generates a valid HS512 signed JWT token', async () => {
+    const token = await generateJwt({ alg: 'HS512', typ: 'JWT' }, payload, secret, 'HS512');
+    const parts = token.split('.');
+    expect(parts.length).toBe(3);
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('HS512');
+  });
+
+  it('generates an unsigned (alg: none) JWT token without a signature', async () => {
+    const token = await generateJwt({ alg: 'none', typ: 'JWT' }, payload, '', 'none');
+    const parts = token.split('.');
+    expect(parts.length).toBe(3);
+    expect(parts[2]).toBe('');
+
+    const decoded = decodeJwt(token);
+    expect(decoded.isValid).toBe(true);
+    expect(decoded.header.alg).toBe('none');
+    expect(decoded.payload.email).toBe('dev@voiden.io');
+  });
+
+  it('throws error when secret is missing for HMAC algorithm', async () => {
+    await expect(
+      generateJwt({ alg: 'HS256', typ: 'JWT' }, payload, '', 'HS256')
+    ).rejects.toThrow('Secret key is required for HS256 signing');
+  });
+});
+
+describe('JWT Faker - Decoding & Error Handling', () => {
+  it('returns invalid state for malformed or empty token strings', () => {
+    const emptyResult = decodeJwt('');
+    expect(emptyResult.isValid).toBe(false);
+    expect(emptyResult.error).toContain('Token string is empty');
+
+    const invalidResult = decodeJwt('not-a-jwt');
+    expect(invalidResult.isValid).toBe(false);
+    expect(invalidResult.error).toContain('Invalid JWT format');
+  });
+});
+
+describe('JWT Faker - Claim Timestamp Utilities', () => {
+  it('calculates current and offset claim timestamps in seconds', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const iat = getClaimTimestamp(0);
+    const exp = getClaimTimestamp(3600);
+
+    expect(iat).toBeGreaterThanOrEqual(now - 2);
+    expect(iat).toBeLessThanOrEqual(now + 2);
+    expect(exp - iat).toBe(3600);
+  });
+});

--- a/plugins/jwt-faker/src/components/JwtFakerModal.tsx
+++ b/plugins/jwt-faker/src/components/JwtFakerModal.tsx
@@ -1,0 +1,416 @@
+import { useState, useEffect } from 'react';
+import {
+  generateJwt,
+  decodeJwt,
+  getClaimTimestamp,
+} from '../utils/jwtUtils';
+import type { JwtAlgorithm, JwtTemplate } from '../utils/types';
+import { Copy, Check, Sparkles, RefreshCw, X } from 'lucide-react';
+
+interface JwtFakerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  showToast?: (message: string, type?: 'info' | 'success' | 'warning' | 'error') => void;
+}
+
+const DEFAULT_HEADER = JSON.stringify({ alg: 'HS256', typ: 'JWT' }, null, 2);
+const DEFAULT_PAYLOAD = JSON.stringify(
+  {
+    sub: '123456789',
+    name: 'John Doe',
+    email: 'john@example.com',
+    role: 'admin',
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  },
+  null,
+  2
+);
+
+export const JwtFakerModal = ({ isOpen, onClose, showToast }: JwtFakerModalProps) => {
+  const [algorithm, setAlgorithm] = useState<JwtAlgorithm>('HS256');
+  const [secret, setSecret] = useState('your-256-bit-secret');
+  const [headerJson, setHeaderJson] = useState(DEFAULT_HEADER);
+  const [payloadJson, setPayloadJson] = useState(DEFAULT_PAYLOAD);
+  const [generatedJwt, setGeneratedJwt] = useState('');
+  const [copied, setCopied] = useState(false);
+  const [activeTab, setActiveTab] = useState<'editor' | 'decoder' | 'templates'>('editor');
+  const [inputTokenToDecode, setInputTokenToDecode] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  // Saved templates
+  const [templates, setTemplates] = useState<JwtTemplate[]>(() => {
+    try {
+      const saved = localStorage.getItem('__voiden_jwt_templates__');
+      return saved ? JSON.parse(saved) : [];
+    } catch {
+      return [];
+    }
+  });
+  const [templateName, setTemplateName] = useState('');
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('__voiden_jwt_templates__', JSON.stringify(templates));
+    } catch {
+      // Ignore storage errors
+    }
+  }, [templates]);
+
+  // Re-generate JWT whenever inputs change
+  useEffect(() => {
+    let isSubscribed = true;
+    const generate = async () => {
+      try {
+        setParseError(null);
+        let headerObj = {};
+        let payloadObj = {};
+
+        try {
+          headerObj = JSON.parse(headerJson);
+        } catch {
+          setParseError('Invalid JSON in Header');
+          return;
+        }
+
+        try {
+          payloadObj = JSON.parse(payloadJson);
+        } catch {
+          setParseError('Invalid JSON in Payload');
+          return;
+        }
+
+        const token = await generateJwt(headerObj, payloadObj, secret, algorithm);
+        if (isSubscribed) {
+          setGeneratedJwt(token);
+        }
+      } catch (err) {
+        if (isSubscribed) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setParseError(msg);
+        }
+      }
+    };
+
+    generate();
+    return () => {
+      isSubscribed = false;
+    };
+  }, [algorithm, secret, headerJson, payloadJson]);
+
+  if (!isOpen) return null;
+
+  const handleCopy = () => {
+    if (!generatedJwt) return;
+    navigator.clipboard.writeText(generatedJwt);
+    setCopied(true);
+    showToast?.('JWT copied to clipboard!', 'success');
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleAddClaim = (claimName: string, value: any) => {
+    try {
+      const current = JSON.parse(payloadJson || '{}');
+      current[claimName] = value;
+      setPayloadJson(JSON.stringify(current, null, 2));
+    } catch {
+      // Ignore parse error
+    }
+  };
+
+  const handleSaveTemplate = () => {
+    if (!templateName.trim()) return;
+    const newTemplate: JwtTemplate = {
+      id: Date.now().toString(),
+      name: templateName.trim(),
+      algorithm,
+      secret,
+      header: headerJson,
+      payload: payloadJson,
+    };
+    setTemplates([...templates, newTemplate]);
+    setTemplateName('');
+    showToast?.(`Saved template "${newTemplate.name}"`, 'success');
+  };
+
+  const handleLoadTemplate = (tpl: JwtTemplate) => {
+    setAlgorithm(tpl.algorithm);
+    setSecret(tpl.secret);
+    setHeaderJson(tpl.header);
+    setPayloadJson(tpl.payload);
+    setActiveTab('editor');
+    showToast?.(`Loaded template "${tpl.name}"`, 'info');
+  };
+
+  const handleDeleteTemplate = (id: string) => {
+    setTemplates(templates.filter((t) => t.id !== id));
+  };
+
+  const decoded = decodeJwt(activeTab === 'decoder' ? inputTokenToDecode || generatedJwt : generatedJwt);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="bg-panel border border-border rounded-lg shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col text-foreground overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/20">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-yellow-500" />
+            <h2 className="text-base font-semibold">JWT Faker & Generator</h2>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Tabs */}
+            <div className="flex bg-muted/40 rounded p-0.5 text-xs">
+              <button
+                className={`px-3 py-1 rounded transition-colors ${
+                  activeTab === 'editor' ? 'bg-primary text-primary-foreground font-medium' : 'text-muted hover:text-foreground'
+                }`}
+                onClick={() => setActiveTab('editor')}
+              >
+                Generator
+              </button>
+              <button
+                className={`px-3 py-1 rounded transition-colors ${
+                  activeTab === 'decoder' ? 'bg-primary text-primary-foreground font-medium' : 'text-muted hover:text-foreground'
+                }`}
+                onClick={() => {
+                  setActiveTab('decoder');
+                  if (!inputTokenToDecode) setInputTokenToDecode(generatedJwt);
+                }}
+              >
+                Decoder
+              </button>
+              <button
+                className={`px-3 py-1 rounded transition-colors ${
+                  activeTab === 'templates' ? 'bg-primary text-primary-foreground font-medium' : 'text-muted hover:text-foreground'
+                }`}
+                onClick={() => setActiveTab('templates')}
+              >
+                Templates ({templates.length})
+              </button>
+            </div>
+
+            <button onClick={onClose} className="p-1 text-muted hover:text-foreground rounded">
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {activeTab === 'editor' && (
+            <>
+              {/* Algorithm & Secret */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs font-medium text-muted mb-1">Algorithm</label>
+                  <select
+                    value={algorithm}
+                    onChange={(e) => setAlgorithm(e.target.value as JwtAlgorithm)}
+                    className="w-full bg-input border border-border rounded px-2.5 py-1.5 text-sm focus:ring-1 focus:ring-primary"
+                  >
+                    <option value="HS256">HS256 (HMAC SHA-256)</option>
+                    <option value="HS384">HS384 (HMAC SHA-384)</option>
+                    <option value="HS512">HS512 (HMAC SHA-512)</option>
+                    <option value="none">none (Unsigned Token)</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-muted mb-1">
+                    Secret Key {algorithm === 'none' && '(Not required for unsigned)'}
+                  </label>
+                  <input
+                    type="text"
+                    value={secret}
+                    onChange={(e) => setSecret(e.target.value)}
+                    disabled={algorithm === 'none'}
+                    placeholder="Enter signing secret"
+                    className="w-full bg-input border border-border rounded px-2.5 py-1.5 text-sm disabled:opacity-50 focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+              </div>
+
+              {/* Payload Claim Quick Buttons */}
+              <div className="flex flex-wrap items-center gap-2 text-xs">
+                <span className="text-muted font-medium">Quick Claims:</span>
+                <button
+                  onClick={() => handleAddClaim('exp', getClaimTimestamp(3600))}
+                  className="px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors"
+                >
+                  +1h Exp
+                </button>
+                <button
+                  onClick={() => handleAddClaim('exp', getClaimTimestamp(86400))}
+                  className="px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors"
+                >
+                  +1d Exp
+                </button>
+                <button
+                  onClick={() => handleAddClaim('iat', getClaimTimestamp(0))}
+                  className="px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors"
+                >
+                  Set iat Now
+                </button>
+                <button
+                  onClick={() => handleAddClaim('nbf', getClaimTimestamp(0))}
+                  className="px-2 py-1 bg-muted/40 hover:bg-muted/70 rounded text-foreground transition-colors"
+                >
+                  Set nbf Now
+                </button>
+              </div>
+
+              {/* JSON Editors */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="text-xs font-medium text-muted">Header (JSON)</label>
+                  </div>
+                  <textarea
+                    rows={6}
+                    value={headerJson}
+                    onChange={(e) => setHeaderJson(e.target.value)}
+                    className="w-full font-mono text-xs bg-input border border-border rounded p-2 focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="text-xs font-medium text-muted">Payload (JSON)</label>
+                  </div>
+                  <textarea
+                    rows={6}
+                    value={payloadJson}
+                    onChange={(e) => setPayloadJson(e.target.value)}
+                    className="w-full font-mono text-xs bg-input border border-border rounded p-2 focus:ring-1 focus:ring-primary"
+                  />
+                </div>
+              </div>
+
+              {/* Parse Error */}
+              {parseError && (
+                <div className="text-xs text-red-500 bg-red-500/10 border border-red-500/30 rounded px-2.5 py-1.5">
+                  {parseError}
+                </div>
+              )}
+
+              {/* Encoded Token Result */}
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="text-xs font-semibold text-foreground">Generated Encoded JWT</label>
+                  <button
+                    onClick={handleCopy}
+                    disabled={!generatedJwt}
+                    className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-primary hover:bg-primary/90 text-primary-foreground font-medium rounded transition-colors"
+                  >
+                    {copied ? <Check size={14} /> : <Copy size={14} />}
+                    {copied ? 'Copied!' : 'Copy JWT'}
+                  </button>
+                </div>
+                <textarea
+                  readOnly
+                  rows={3}
+                  value={generatedJwt}
+                  className="w-full font-mono text-xs bg-muted/20 border border-border rounded p-2 text-yellow-500 select-all"
+                />
+              </div>
+
+              {/* Save Template Bar */}
+              <div className="flex items-center gap-2 pt-2 border-t border-border">
+                <input
+                  type="text"
+                  placeholder="Template name (e.g. Admin Token)"
+                  value={templateName}
+                  onChange={(e) => setTemplateName(e.target.value)}
+                  className="flex-1 bg-input border border-border rounded px-2.5 py-1 text-xs"
+                />
+                <button
+                  onClick={handleSaveTemplate}
+                  disabled={!templateName.trim()}
+                  className="px-3 py-1 bg-muted hover:bg-muted/80 text-xs font-medium rounded transition-colors disabled:opacity-50"
+                >
+                  Save as Template
+                </button>
+              </div>
+            </>
+          )}
+
+          {activeTab === 'decoder' && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-muted mb-1">JWT Token to Decode</label>
+                <textarea
+                  rows={3}
+                  value={inputTokenToDecode}
+                  onChange={(e) => setInputTokenToDecode(e.target.value)}
+                  placeholder="Paste JWT token here..."
+                  className="w-full font-mono text-xs bg-input border border-border rounded p-2"
+                />
+              </div>
+
+              {decoded.isValid ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <span className="block text-xs font-semibold text-red-400 mb-1">Decoded Header</span>
+                    <pre className="font-mono text-xs bg-muted/20 border border-border rounded p-2 overflow-x-auto text-red-400">
+                      {JSON.stringify(decoded.header, null, 2)}
+                    </pre>
+                  </div>
+
+                  <div>
+                    <span className="block text-xs font-semibold text-purple-400 mb-1">Decoded Payload</span>
+                    <pre className="font-mono text-xs bg-muted/20 border border-border rounded p-2 overflow-x-auto text-purple-400">
+                      {JSON.stringify(decoded.payload, null, 2)}
+                    </pre>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-xs text-red-500 bg-red-500/10 border border-red-500/30 rounded p-2">
+                  {decoded.error || 'Invalid token structure'}
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'templates' && (
+            <div className="space-y-3">
+              {templates.length === 0 ? (
+                <div className="text-xs text-muted text-center py-6">
+                  No saved templates yet. Customize claims in the Generator and click "Save as Template".
+                </div>
+              ) : (
+                templates.map((tpl) => (
+                  <div
+                    key={tpl.id}
+                    className="flex items-center justify-between p-2.5 border border-border rounded bg-muted/10 hover:bg-muted/20"
+                  >
+                    <div>
+                      <div className="text-xs font-semibold text-foreground">{tpl.name}</div>
+                      <div className="text-[11px] text-muted">
+                        Alg: {tpl.algorithm} | Key: {tpl.secret || '(none)'}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleLoadTemplate(tpl)}
+                        className="px-2.5 py-1 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90"
+                      >
+                        Load
+                      </button>
+                      <button
+                        onClick={() => handleDeleteTemplate(tpl.id)}
+                        className="p-1 text-muted hover:text-red-500"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/plugins/jwt-faker/src/index.ts
+++ b/plugins/jwt-faker/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * JWT Faker Plugin
+ */
+
+export { default } from './main';
+export { JwtFakerModal } from './components/JwtFakerModal';
+export * from './utils/types';
+export * from './utils/jwtUtils';

--- a/plugins/jwt-faker/src/main.ts
+++ b/plugins/jwt-faker/src/main.ts
@@ -1,7 +1,8 @@
 /**
  * JWT Faker Plugin
  *
- * Enables generating, customizing, signing, decoding, and copying JSON Web Tokens (JWTs) for API authentication testing.
+ * Provides JSON Web Token (JWT) generation, HMAC signing (HS256, HS384, HS512),
+ * unsigned token support (alg: none), decoding, claim quick-helpers, and template management.
  */
 
 import type { PluginContext } from '@voiden/sdk/ui';

--- a/plugins/jwt-faker/src/main.ts
+++ b/plugins/jwt-faker/src/main.ts
@@ -1,0 +1,80 @@
+/**
+ * JWT Faker Plugin
+ *
+ * Enables generating, customizing, signing, decoding, and copying JSON Web Tokens (JWTs) for API authentication testing.
+ */
+
+import type { PluginContext } from '@voiden/sdk/ui';
+import React from 'react';
+import { JwtFakerModal } from './components/JwtFakerModal';
+
+const jwtFakerPlugin = (context: PluginContext) => {
+  const showToast = (context as any)?.ui?.showToast as
+    | ((message: string, type?: 'info' | 'success' | 'warning' | 'error') => void)
+    | undefined;
+
+  let modalRoot: HTMLElement | null = null;
+  let isModalOpen = false;
+
+  const renderModal = () => {
+    if (!modalRoot) {
+      modalRoot = document.createElement('div');
+      modalRoot.id = 'jwt-faker-modal-root';
+      document.body.appendChild(modalRoot);
+    }
+
+    const { createRoot } = (window as any).__voiden_shims__?.['react-dom/client'] || {};
+    if (createRoot) {
+      if (!(modalRoot as any)._reactRoot) {
+        (modalRoot as any)._reactRoot = createRoot(modalRoot);
+      }
+      (modalRoot as any)._reactRoot.render(
+        React.createElement(JwtFakerModal, {
+          isOpen: isModalOpen,
+          onClose: () => {
+            isModalOpen = false;
+            renderModal();
+          },
+          showToast,
+        })
+      );
+    }
+  };
+
+  return {
+    onload: () => {
+      // Expose global helper to open modal
+      (window as any).__voidenOpenJwtFaker__ = () => {
+        isModalOpen = true;
+        renderModal();
+      };
+
+      // Register status bar item
+      if (typeof context.registerStatusBarItem === 'function') {
+        context.registerStatusBarItem({
+          id: 'jwt-faker-status-item',
+          text: 'JWT Faker',
+          icon: 'Sparkles',
+          tooltip: 'Generate and decode JWT tokens for testing',
+          onClick: () => {
+            isModalOpen = true;
+            renderModal();
+          },
+        });
+      }
+    },
+
+    onunload: () => {
+      delete (window as any).__voidenOpenJwtFaker__;
+      if (modalRoot) {
+        if ((modalRoot as any)._reactRoot) {
+          (modalRoot as any)._reactRoot.unmount();
+        }
+        modalRoot.remove();
+        modalRoot = null;
+      }
+    },
+  };
+};
+
+export default jwtFakerPlugin;

--- a/plugins/jwt-faker/src/utils/jwtUtils.ts
+++ b/plugins/jwt-faker/src/utils/jwtUtils.ts
@@ -1,0 +1,190 @@
+import type {
+  JwtAlgorithm,
+  JwtHeader,
+  JwtPayload,
+  DecodedJwt,
+} from './types';
+
+/**
+ * Base64Url encode string / Uint8Array
+ */
+export function base64urlEncode(input: string | Uint8Array): string {
+  let base64 = '';
+  if (typeof input === 'string') {
+    // UTF-8 encode string to base64
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(input);
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    base64 = btoa(binary);
+  } else {
+    let binary = '';
+    for (let i = 0; i < input.byteLength; i++) {
+      binary += String.fromCharCode(input[i]);
+    }
+    base64 = btoa(binary);
+  }
+
+  return base64.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+/**
+ * Base64Url decode string
+ */
+export function base64urlDecode(str: string): string {
+  let base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4 !== 0) {
+    base64 += '=';
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const decoder = new TextDecoder();
+  return decoder.decode(bytes);
+}
+
+/**
+ * Get hash algorithm name for Web Crypto
+ */
+function getHashName(algorithm: JwtAlgorithm): string {
+  switch (algorithm) {
+    case 'HS256':
+      return 'SHA-256';
+    case 'HS384':
+      return 'SHA-384';
+    case 'HS512':
+      return 'SHA-512';
+    default:
+      throw new Error(`Unsupported HMAC algorithm: ${algorithm}`);
+  }
+}
+
+/**
+ * Sign HMAC signature using Web Crypto API
+ */
+export async function signHmac(
+  algorithm: 'HS256' | 'HS384' | 'HS512',
+  secret: string,
+  data: string
+): Promise<string> {
+  const hashName = getHashName(algorithm);
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(secret);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: { name: hashName } },
+    false,
+    ['sign']
+  );
+
+  const signatureBuffer = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    encoder.encode(data)
+  );
+
+  return base64urlEncode(new Uint8Array(signatureBuffer));
+}
+
+/**
+ * Generate JWT string from Header, Payload, Secret, and Algorithm
+ */
+export async function generateJwt(
+  header: JwtHeader,
+  payload: JwtPayload,
+  secret: string,
+  algorithm: JwtAlgorithm = 'HS256'
+): Promise<string> {
+  const fullHeader: JwtHeader = {
+    alg: algorithm,
+    typ: 'JWT',
+    ...header,
+  };
+
+  const encodedHeader = base64urlEncode(JSON.stringify(fullHeader));
+  const encodedPayload = base64urlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  if (algorithm === 'none') {
+    return `${signingInput}.`;
+  }
+
+  if (!secret) {
+    throw new Error(`Secret key is required for ${algorithm} signing`);
+  }
+
+  const signature = await signHmac(algorithm, secret, signingInput);
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Decode JWT token into Header, Payload, and Signature
+ */
+export function decodeJwt(token: string): DecodedJwt {
+  if (!token || typeof token !== 'string') {
+    return {
+      header: { alg: 'none', typ: 'JWT' },
+      payload: {},
+      signature: '',
+      rawHeader: '',
+      rawPayload: '',
+      isValid: false,
+      error: 'Token string is empty',
+    };
+  }
+
+  const parts = token.trim().split('.');
+  if (parts.length < 2 || parts.length > 3) {
+    return {
+      header: { alg: 'none', typ: 'JWT' },
+      payload: {},
+      signature: '',
+      rawHeader: '',
+      rawPayload: '',
+      isValid: false,
+      error: 'Invalid JWT format: must contain header, payload, and signature sections',
+    };
+  }
+
+  try {
+    const rawHeader = base64urlDecode(parts[0]);
+    const rawPayload = base64urlDecode(parts[1]);
+    const signature = parts[2] || '';
+
+    const header = JSON.parse(rawHeader);
+    const payload = JSON.parse(rawPayload);
+
+    return {
+      header,
+      payload,
+      signature,
+      rawHeader,
+      rawPayload,
+      isValid: true,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      header: { alg: 'none', typ: 'JWT' },
+      payload: {},
+      signature: parts[2] || '',
+      rawHeader: parts[0] || '',
+      rawPayload: parts[1] || '',
+      isValid: false,
+      error: `Failed to decode JWT: ${msg}`,
+    };
+  }
+}
+
+/**
+ * Calculate epoch timestamp in seconds for claims
+ */
+export function getClaimTimestamp(offsetSeconds: number = 0): number {
+  return Math.floor(Date.now() / 1000) + offsetSeconds;
+}

--- a/plugins/jwt-faker/src/utils/jwtUtils.ts
+++ b/plugins/jwt-faker/src/utils/jwtUtils.ts
@@ -102,8 +102,8 @@ export async function generateJwt(
   algorithm: JwtAlgorithm = 'HS256'
 ): Promise<string> {
   const fullHeader: JwtHeader = {
-    typ: 'JWT',
     ...header,
+    typ: header.typ || 'JWT',
     alg: algorithm,
   };
 

--- a/plugins/jwt-faker/src/utils/jwtUtils.ts
+++ b/plugins/jwt-faker/src/utils/jwtUtils.ts
@@ -102,9 +102,9 @@ export async function generateJwt(
   algorithm: JwtAlgorithm = 'HS256'
 ): Promise<string> {
   const fullHeader: JwtHeader = {
-    alg: algorithm,
     typ: 'JWT',
     ...header,
+    alg: algorithm,
   };
 
   const encodedHeader = base64urlEncode(JSON.stringify(fullHeader));

--- a/plugins/jwt-faker/src/utils/types.ts
+++ b/plugins/jwt-faker/src/utils/types.ts
@@ -1,0 +1,45 @@
+export type JwtAlgorithm = 'HS256' | 'HS384' | 'HS512' | 'none';
+
+export interface JwtHeader {
+  alg: JwtAlgorithm;
+  typ: string;
+  [key: string]: any;
+}
+
+export interface JwtPayload {
+  sub?: string;
+  email?: string;
+  role?: string;
+  iat?: number;
+  exp?: number;
+  nbf?: number;
+  iss?: string;
+  aud?: string;
+  [key: string]: any;
+}
+
+export interface JwtGeneratorOptions {
+  algorithm: JwtAlgorithm;
+  secret: string;
+  header: JwtHeader;
+  payload: JwtPayload;
+}
+
+export interface DecodedJwt {
+  header: JwtHeader;
+  payload: JwtPayload;
+  signature: string;
+  rawHeader: string;
+  rawPayload: string;
+  isValid: boolean;
+  error?: string;
+}
+
+export interface JwtTemplate {
+  id: string;
+  name: string;
+  algorithm: JwtAlgorithm;
+  secret: string;
+  header: string;
+  payload: string;
+}


### PR DESCRIPTION
## Description
Closes #515

Add a JWT Faker plugin (`plugins/jwt-faker`) that enables developers to generate, customize, sign, decode, and copy JSON Web Tokens (JWTs) directly within Voiden for API authentication testing.

## Features & Implementation
- **HMAC Algorithms & Signing**:
  - `HS256` (HMAC SHA-256)
  - `HS384` (HMAC SHA-384)
  - `HS512` (HMAC SHA-512)
  - `none` (Unsigned tokens)
- **Editors & Claim Helpers**:
  - Custom JSON Header editor
  - Custom JSON Payload editor
  - Claim quick buttons: `+1h exp`, `+1d exp`, set `iat`, set `nbf`
- **Decoder & Templates**:
  - Live preview of decoded header and payload
  - Template manager to save & load reusable claim configurations
  - One-click copy token to clipboard
- **Registry Integration**: Registered `jwt-faker` in plugin registry and synced to Electron host.

## Testing
- Unit tests (`plugins/jwt-faker/src/__tests__/jwtUtils.test.ts`): 8/8 passed.
