### PR TITLE
fix: preserve file explorer state on save

### DIFF
--- a/apps/ui/src/core/file-system/hooks/__test__/fileSaveInvalidation.test.ts
+++ b/apps/ui/src/core/file-system/hooks/__test__/fileSaveInvalidation.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { invalidateFileSaveQueries } from "../fileSaveInvalidation";
+
+describe("invalidateFileSaveQueries", () => {
+  it("refreshes saved tab data without invalidating the file tree", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateFileSaveQueries(queryClient, "main", "tab-1");
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(2);
+    expect(invalidateQueries).toHaveBeenNthCalledWith(1, {
+      queryKey: ["panel:tabs", "main"],
+    });
+    expect(invalidateQueries).toHaveBeenNthCalledWith(2, {
+      queryKey: ["tab:content", "main", "tab-1"],
+    });
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: expect.arrayContaining(["files:tree"]),
+      }),
+    );
+  });
+
+  it("refreshes the file tree when saving creates a file", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    invalidateFileSaveQueries(queryClient, "main", "tab-1", {
+      activeDirectory: "/project",
+      fileTreeChanged: true,
+    });
+
+    expect(invalidateQueries).toHaveBeenNthCalledWith(3, {
+      queryKey: ["files:tree", "/project"],
+    });
+  });
+});

--- a/apps/ui/src/core/file-system/hooks/fileSaveInvalidation.ts
+++ b/apps/ui/src/core/file-system/hooks/fileSaveInvalidation.ts
@@ -1,0 +1,26 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+type FileSaveInvalidationOptions = {
+  activeDirectory?: string;
+  fileTreeChanged?: boolean;
+};
+
+export function invalidateFileSaveQueries(
+  queryClient: QueryClient,
+  panelId: string,
+  tabId: string,
+  options: FileSaveInvalidationOptions = {},
+): void {
+  // Saving changes file contents, not the explorer structure. Invalidating
+  // files:tree here rebuilds react-arborist nodes and loses expanded folders.
+  void queryClient.invalidateQueries({ queryKey: ["panel:tabs", panelId] });
+  void queryClient.invalidateQueries({
+    queryKey: ["tab:content", panelId, tabId],
+  });
+
+  if (options.fileTreeChanged) {
+    void queryClient.invalidateQueries({
+      queryKey: ["files:tree", options.activeDirectory],
+    });
+  }
+}

--- a/apps/ui/src/core/file-system/hooks/useFileSystem.ts
+++ b/apps/ui/src/core/file-system/hooks/useFileSystem.ts
@@ -10,6 +10,7 @@ import { Schema } from "@tiptap/pm/model";
 import { getSchema } from "@tiptap/core";
 import { useCodeEditorStore } from "@/core/editors/code/CodeEditorStore";
 import { useEditorEnhancementStore } from "@/plugins";
+import { invalidateFileSaveQueries } from "./fileSaveInvalidation";
 import { isPathInsideLockedProject } from "./useProjectLock";
 import { toast } from "@/core/components/ui/sonner";
 
@@ -99,13 +100,15 @@ export const prosemirrorToMarkdown = (content: string, schema: Schema) => {
   return markdownWithVersion;
 };
 
-export const invalidateOnFileSave = (path: string, panelId: string, tabId: string) => {
+export const invalidateOnFileSave = (panelId: string, tabId: string, fileTreeChanged = false) => {
   const queryClient = getQueryClient();
-  const appState = queryClient.getQueryData<any>(["app:state"]);
-  const activeDirectory = appState?.activeDirectory;
-  queryClient.invalidateQueries({ queryKey: ["panel:tabs", panelId] });
-  queryClient.invalidateQueries({ queryKey: ["tab:content", panelId, tabId] });
-  queryClient.invalidateQueries({ queryKey: ["files:tree", activeDirectory] });
+  const appState = fileTreeChanged
+    ? queryClient.getQueryData<{ activeDirectory?: string }>(["app:state"])
+    : undefined;
+  invalidateFileSaveQueries(queryClient, panelId, tabId, {
+    activeDirectory: appState?.activeDirectory,
+    fileTreeChanged,
+  });
 };
 
 export const saveFileUtil = async (path: string | null, content: string, panelId: string, tabId: string, schema: Schema) => {
@@ -128,7 +131,7 @@ export const saveFileUtil = async (path: string | null, content: string, panelId
   // For new (previously unsaved) files, register now that we have the real path.
   if (!path) registerSelfSave(filePath);
 
-  invalidateOnFileSave(filePath, panelId, tabId);
+  invalidateOnFileSave(panelId, tabId, path === null);
 
   useEditorStore.getState().clearUnsaved(tabId);
   useVoidenEditorStore.getState().setFilePath(filePath);
@@ -615,7 +618,7 @@ export const saveTabById = async (tabId: string, options?: { silent?: boolean })
       
       await window.electron?.files.write(tab.source, unsavedContent);
       if (shouldInvalidate) {
-        invalidateOnFileSave(tab.source, "main", tabId);
+        invalidateOnFileSave("main", tabId);
       } else {
         syncTabContentCache(unsavedContent);
       }
@@ -704,7 +707,7 @@ export const globalSaveFile = async () => {
             ? view.state.doc.toString()
             : activeEditor.content;
           await writeFileChunked(activeEditor.source, content);
-          invalidateOnFileSave(activeEditor.source, activeEditor.panelId || "", activeEditor.tabId);
+          invalidateOnFileSave(activeEditor.panelId || "", activeEditor.tabId);
           useEditorStore.getState().clearUnsaved(activeEditor.tabId);
           return true;
         } catch (error) {
@@ -736,7 +739,7 @@ export const globalSaveFile = async () => {
           ? view.state.doc.toString()
           : activeEditor.content;
         await writeFileChunked(activeEditor.source, content);
-        invalidateOnFileSave(activeEditor.source, activeEditor.panelId || "", activeEditor.tabId);
+        invalidateOnFileSave(activeEditor.panelId || "", activeEditor.tabId);
         useEditorStore.getState().clearUnsaved(activeEditor.tabId);
         return true;
       } catch (error) {


### PR DESCRIPTION
## Summary

- stop existing-file saves from invalidating the File Explorer tree query
- keep tree invalidation for the first save of a new, previously unsaved file
- add regression coverage for both invalidation paths

## Root cause

`invalidateOnFileSave` invalidated `files:tree` for every content save. That refetched and rebuilt the react-arborist tree even though the directory structure had not changed, which discarded the user's expanded-folder state after Cmd/Ctrl+S.

The save path now invalidates only the affected panel and tab content for existing files. A new file's first save still refreshes the tree because that operation changes its structure.

## Testing

- `corepack yarn workspace voiden-ui test --run src/core/file-system/hooks/__test__/fileSaveInvalidation.test.ts` (2 passed)
- focused TypeScript check for the new helper and regression test (passed)
- ESLint for the new helper and regression test (passed)
- full UI suite: 192 tests passed; the run still reports two unrelated existing failures in the pipeline response-body assertion and the plugin-context mock

Fixes #543
