### PR TITLE
Stop file tree from refreshing on every save

### DIFF
--- a/apps/ui/src/core/file-system/hooks/__test__/useFileSystem.test.ts
+++ b/apps/ui/src/core/file-system/hooks/__test__/useFileSystem.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const invalidateQueries = vi.fn();
+const getQueryData = vi.fn(() => ({ activeDirectory: "/mock/project" }));
+
+vi.mock("@/main", () => ({
+  getQueryClient: () => ({ invalidateQueries, getQueryData }),
+}));
+
+import { invalidateOnFileSave } from "@/core/file-system/hooks/useFileSystem";
+
+describe("invalidateOnFileSave", () => {
+  beforeEach(() => {
+    invalidateQueries.mockClear();
+    getQueryData.mockClear();
+  });
+
+  const invalidatedKeys = () => invalidateQueries.mock.calls.map((call) => call[0].queryKey);
+
+  it("does not refresh the file tree when saving an existing file", () => {
+    invalidateOnFileSave("/mock/project/notes.void", "main", "tab-1");
+
+    const keys = invalidatedKeys();
+    expect(keys).toContainEqual(["panel:tabs", "main"]);
+    expect(keys).toContainEqual(["tab:content", "main", "tab-1"]);
+    expect(keys.some((key) => key[0] === "files:tree")).toBe(false);
+  });
+
+  it("still refreshes the file tree when a new file is created", () => {
+    invalidateOnFileSave(null, "main", "tab-1");
+
+    const keys = invalidatedKeys();
+    expect(keys).toContainEqual(["files:tree", "/mock/project"]);
+  });
+});

--- a/apps/ui/src/core/file-system/hooks/useFileSystem.ts
+++ b/apps/ui/src/core/file-system/hooks/useFileSystem.ts
@@ -99,13 +99,18 @@ export const prosemirrorToMarkdown = (content: string, schema: Schema) => {
   return markdownWithVersion;
 };
 
-export const invalidateOnFileSave = (path: string, panelId: string, tabId: string) => {
+export const invalidateOnFileSave = (path: string | null, panelId: string, tabId: string) => {
   const queryClient = getQueryClient();
-  const appState = queryClient.getQueryData<any>(["app:state"]);
-  const activeDirectory = appState?.activeDirectory;
   queryClient.invalidateQueries({ queryKey: ["panel:tabs", panelId] });
   queryClient.invalidateQueries({ queryKey: ["tab:content", panelId, tabId] });
-  queryClient.invalidateQueries({ queryKey: ["files:tree", activeDirectory] });
+  // Saving existing file contents doesn't change the directory structure, so
+  // only refresh the tree when a new file was just created (path was unknown
+  // until the write resolved it) and needs to appear in it.
+  if (!path) {
+    const appState = queryClient.getQueryData<any>(["app:state"]);
+    const activeDirectory = appState?.activeDirectory;
+    queryClient.invalidateQueries({ queryKey: ["files:tree", activeDirectory] });
+  }
 };
 
 export const saveFileUtil = async (path: string | null, content: string, panelId: string, tabId: string, schema: Schema) => {
@@ -128,7 +133,7 @@ export const saveFileUtil = async (path: string | null, content: string, panelId
   // For new (previously unsaved) files, register now that we have the real path.
   if (!path) registerSelfSave(filePath);
 
-  invalidateOnFileSave(filePath, panelId, tabId);
+  invalidateOnFileSave(path, panelId, tabId);
 
   useEditorStore.getState().clearUnsaved(tabId);
   useVoidenEditorStore.getState().setFilePath(filePath);


### PR DESCRIPTION
## Summary

Saving a file (Cmd/Ctrl+S) was invalidating the `files:tree` query on every save via `invalidateOnFileSave`, even though saving existing file contents doesn't change the directory structure. This caused any expanded folders in the file explorer to collapse on save.

`invalidateOnFileSave` now only refreshes `files:tree` when the save just created a brand new file (i.e. `path` was `null` going in) that needs to appear in the tree. Saves to existing files still refresh `panel:tabs` and `tab:content` as before, just not the tree.

Fixes #543

## Testing

- Added `apps/ui/src/core/file-system/hooks/__test__/useFileSystem.test.ts`: confirms `files:tree` is not invalidated when saving an existing file, and still is when a new file is created.
- `yarn vitest run` in `apps/ui`: 194 tests, same 2 pre-existing unrelated failures as on a clean `beta` checkout (`plugincontext.test.ts` missing mock export, `pipeline.test.ts` response-parsing assertion) — verified via `git stash` that both fail identically without this change.
- `tsc --noEmit`: no new errors introduced (2 pre-existing errors elsewhere in the same file, unrelated to the changed lines).