### PR TITLE
feat(auth): add AWS SigV4 request signing

### DIFF
--- a/apps/ui/src/core/request-engine/__test__/environmentOverride.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/environmentOverride.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { applyEnvironmentOverrideToRequest } from '../environmentOverride'
+
+describe('request orchestrator environment override', () => {
+  it('substitutes AWS auth config without exposing it through headers or logs', () => {
+    const request = {
+      url: 'https://{{HOST}}/resource',
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: {
+          accessKey: '{{AWS_ACCESS_KEY}}',
+          secretKey: '{{AWS_SECRET_KEY}}',
+          sessionToken: '{{AWS_SESSION_TOKEN}}',
+          region: '{{AWS_REGION}}',
+          service: '{{AWS_SERVICE}}',
+          nonStringOption: true,
+        },
+      },
+    }
+
+    applyEnvironmentOverrideToRequest(request, {
+      HOST: 'example.amazonaws.com',
+      AWS_ACCESS_KEY: 'access-key',
+      AWS_SECRET_KEY: 'secret-key',
+      AWS_SESSION_TOKEN: 'session-token',
+      AWS_REGION: 'us-east-1',
+      AWS_SERVICE: 'execute-api',
+    })
+
+    expect(request).toEqual({
+      url: 'https://example.amazonaws.com/resource',
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: {
+          accessKey: 'access-key',
+          secretKey: 'secret-key',
+          sessionToken: 'session-token',
+          region: 'us-east-1',
+          service: 'execute-api',
+          nonStringOption: true,
+        },
+      },
+    })
+  })
+})

--- a/apps/ui/src/core/request-engine/__test__/sendRequestHybrid.validation.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/sendRequestHybrid.validation.test.ts
@@ -84,6 +84,32 @@ describe("sendRequestHybrid unresolved variable handling", () => {
     expect(response?.statusCode).toBe(200);
   });
 
+  it("voiden test : forwards AWS auth templates to the secure executor", async () => {
+    const auth = {
+      enabled: true,
+      type: "aws-signature",
+      config: {
+        accessKey: "{{AWS_ACCESS_KEY}}",
+        secretKey: "{{AWS_SECRET_KEY}}",
+        sessionToken: "{{AWS_SESSION_TOKEN}}",
+        region: "us-east-1",
+        service: "execute-api",
+      },
+    };
+
+    await sendRequestHybrid(
+      restRequest({ url: "https://example.amazonaws.com", auth }),
+      createMockEditor(),
+      undefined,
+      mockElectron,
+    );
+
+    expect(sendSecure).toHaveBeenCalledWith(
+      expect.objectContaining({ auth }),
+      undefined,
+    );
+  });
+
   it("voiden test : throws when sendSecure reports unresolved variables after substitution", async () => {
     sendSecure.mockResolvedValueOnce({
       status: 0,

--- a/apps/ui/src/core/request-engine/environmentOverride.ts
+++ b/apps/ui/src/core/request-engine/environmentOverride.ts
@@ -1,0 +1,69 @@
+type RequestRow = Record<string, unknown>
+type EnvironmentOverrideRequest = Record<string, unknown> & {
+  url?: unknown
+  body?: unknown
+  headers?: unknown
+  params?: unknown
+  path_params?: unknown
+  binary?: unknown
+  body_params?: unknown
+  auth?: unknown
+}
+
+/**
+ * Apply scenario-specific environment values to a built request.
+ *
+ * This operates only on the override map already supplied to the renderer; it
+ * never reads the secure active environment. Auth values remain inside the
+ * request and are passed directly to the secure executor without logging.
+ */
+export function applyEnvironmentOverrideToRequest(
+  request: EnvironmentOverrideRequest,
+  environment: Record<string, string>,
+): EnvironmentOverrideRequest {
+  const substitute = (text: string): string =>
+    text.replace(/\{\{([^}]+)\}\}/g, (match, varName) => {
+      const key = varName.trim()
+      return Object.prototype.hasOwnProperty.call(environment, key) ? environment[key] : match
+    })
+  const replaceRows = (rows: unknown, replaceKey = false): unknown =>
+    Array.isArray(rows)
+      ? rows.map((row: RequestRow) => ({
+          ...row,
+          ...(replaceKey && typeof row.key === 'string' ? { key: substitute(row.key) } : {}),
+          value: typeof row.value === 'string' ? substitute(row.value) : row.value,
+        }))
+      : rows
+
+  if (typeof request.url === 'string') request.url = substitute(request.url)
+  if (typeof request.body === 'string') request.body = substitute(request.body)
+  if (request.headers !== undefined) request.headers = replaceRows(request.headers, true)
+  if (request.params !== undefined) request.params = replaceRows(request.params, true)
+  if (request.path_params !== undefined) request.path_params = replaceRows(request.path_params, true)
+  if (request.body_params !== undefined) request.body_params = replaceRows(request.body_params, true)
+
+  if (typeof request.binary === 'string') {
+    request.binary = substitute(request.binary)
+  } else if (Array.isArray(request.binary)) {
+    request.binary = request.binary.map((value: unknown) =>
+      typeof value === 'string' ? substitute(value) : value,
+    )
+  }
+
+  if (request.auth && typeof request.auth === 'object') {
+    const auth = request.auth as Record<string, unknown>
+    if (auth.config && typeof auth.config === 'object') {
+      request.auth = {
+        ...auth,
+        config: Object.fromEntries(
+          Object.entries(auth.config).map(([key, value]) => [
+            key,
+            typeof value === 'string' ? substitute(value) : value,
+          ]),
+        ),
+      }
+    }
+  }
+
+  return request
+}

--- a/apps/ui/src/core/request-engine/getRequestFromJson.ts
+++ b/apps/ui/src/core/request-engine/getRequestFromJson.ts
@@ -222,7 +222,13 @@ export const parseAuthNode = (editor: Doc) => {
       break;
     case "digest": finalConfig = { username: config.username || "", password: config.password || "", realm: config.realm || "", algorithm: config.algorithm || "MD5" }; break;
     case "ntlm": finalConfig = { username: config.username || "", password: config.password || "", domain: config.domain || "", workstation: config.workstation || "" }; break;
-    case "awsSignature": finalConfig = { accessKey: config.access_key || "", secretKey: config.secret_key || "", region: config.region || "us-east-1", service: config.service || "execute-api" }; break;
+    case "awsSignature": finalConfig = {
+      accessKey: config.access_key || "",
+      secretKey: config.secret_key || "",
+      sessionToken: config.session_token || "",
+      region: config.region || "us-east-1",
+      service: config.service || "execute-api",
+    }; break;
   }
 
   return { enabled: true, type: mappedType, config: finalConfig };
@@ -461,13 +467,24 @@ export function replaceEnvVariablesInRequest(data: Request, environment?: Record
       };
       case "oauth": return { ...authConfig, accessToken: replaceInString(authConfig.accessToken), tokenType: authConfig.tokenType ? replaceInString(authConfig.tokenType) : authConfig.tokenType };
       case "api-key": return { ...authConfig, key: replaceInString(authConfig.key), value: replaceInString(authConfig.value), in: authConfig.in };
+      case "aws-signature": return {
+        ...authConfig,
+        accessKey: replaceInString(authConfig.accessKey),
+        secretKey: replaceInString(authConfig.secretKey),
+        sessionToken: authConfig.sessionToken ? replaceInString(authConfig.sessionToken) : authConfig.sessionToken,
+        region: replaceInString(authConfig.region),
+        service: replaceInString(authConfig.service),
+      };
       default: return authConfig;
     }
   };
 
-  const replacedAuth = data.auth
-    ? { ...data.auth, config: replaceInAuthConfig(data.auth.config, data.auth.type) }
-    : undefined;
+  const replacedAuth = {
+    ...data.auth,
+    ...(data.auth.config
+      ? { config: replaceInAuthConfig(data.auth.config, data.auth.type) }
+      : {}),
+  };
 
   return {
     ...data,

--- a/apps/ui/src/core/request-engine/pipeline/types.ts
+++ b/apps/ui/src/core/request-engine/pipeline/types.ts
@@ -112,7 +112,10 @@ export interface RestApiRequestState {
     type?: string;
     enabled?: boolean;
   }>;
-  binary?: File | string; // File object or file path string
+  binary?: File | string | string[]; // File object or file path string(s)
+
+  // Raw auth templates are resolved/injected only by the secure executor.
+  auth?: Request['auth'];
 
   // Auth profile reference (not the actual credentials)
   authProfile?: string;

--- a/apps/ui/src/core/request-engine/requestOrchestrator.ts
+++ b/apps/ui/src/core/request-engine/requestOrchestrator.ts
@@ -8,10 +8,12 @@
 import { Editor } from "@tiptap/core";
 import { sendRequestHybrid } from "./sendRequestHybrid";
 import type { RequestBuildHandler, ResponseProcessHandler, ResponseSection } from "@voiden/sdk/ui";
+import { mergeRequestHandlerResult } from "@voiden/executors";
 import { requestLogger } from "@/core/lib/logger";
 import { getFirstSectionLabel } from "@/core/editors/voiden/extensions/sectionIndicator";
 import { expandLinkedBlocksInDoc, expandLinkedFilesInDoc } from "@/core/editors/voiden/utils/expandLinkedBlocks";
 import { injectInheritedBlocks } from "./utils/injectInheritedBlocks";
+import { applyEnvironmentOverrideToRequest } from "./environmentOverride";
 
 interface RequestOrchestrator {
   /** Registered request build handlers from plugins */
@@ -212,15 +214,14 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
 
     for (const handler of this.requestHandlers) {
       try {
-        const prevEnvOverride = request?.__envOverride;
-        request = await handler(request, handlerEditor);
-        // Preserve internal metadata across handler chain — handlers that return
-        // a fresh object (e.g. voiden-rest-api) must not silently drop these.
-        if (sectionPos !== undefined && request) {
+        request = mergeRequestHandlerResult(
+          request,
+          await handler(request, handlerEditor),
+        );
+        // Keep the execution-scoped section authoritative even if a plugin
+        // returns its own internal metadata.
+        if (sectionPos !== undefined) {
           request.__sectionPos = sectionPos;
-        }
-        if (prevEnvOverride && request && !request.__envOverride) {
-          request.__envOverride = prevEnvOverride;
         }
       } catch (error) {
         requestLogger.error("Error in plugin request handler:", error);
@@ -232,36 +233,7 @@ class RequestOrchestratorImpl implements RequestOrchestrator {
     // Scenario env vars ({{VAR}}) are resolved here so they work even when no
     // active environment is selected in the UI.
     if (request?.__envOverride && Object.keys(request.__envOverride).length > 0) {
-      const env: Record<string, string> = request.__envOverride;
-      const substitute = (text: string): string =>
-        text.replace(/\{\{([^}]+)\}\}/g, (match, varName) => {
-          const key = varName.trim();
-          return Object.prototype.hasOwnProperty.call(env, key) ? env[key] : match;
-        });
-      if (typeof request.url === 'string') request.url = substitute(request.url);
-      if (typeof request.body === 'string') request.body = substitute(request.body);
-      if (Array.isArray(request.headers)) {
-        request.headers = request.headers.map((h: any) => ({ ...h, value: substitute(String(h.value ?? '')) }));
-      }
-      if (Array.isArray(request.params)) {
-        request.params = request.params.map((p: any) => ({ ...p, value: substitute(String(p.value ?? '')) }));
-      }
-      if (Array.isArray(request.path_params)) {
-        request.path_params = request.path_params.map((p: any) => ({ ...p, value: substitute(String(p.value ?? '')) }));
-      }
-      // Binary file path (restFile / fileLink) — file path can be a {{VAR}} reference
-      if (typeof request.binary === 'string') {
-        request.binary = substitute(request.binary);
-      } else if (Array.isArray(request.binary)) {
-        request.binary = request.binary.map((b: any) => typeof b === 'string' ? substitute(b) : b);
-      }
-      // Multipart body params — substitute values for both text and file entries
-      if (Array.isArray(request.body_params)) {
-        request.body_params = request.body_params.map((p: any) => ({
-          ...p,
-          value: typeof p.value === 'string' ? substitute(p.value) : p.value,
-        }));
-      }
+      request = applyEnvironmentOverrideToRequest(request, request.__envOverride);
     }
 
     // No registered plugin recognized a request-shaped block in this section

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -247,6 +247,9 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
       enabled: p.enabled,
     })),
     binary: data.binary,
+    // Keep credentials/templates raw. The Electron/CLI secure executor resolves
+    // them and performs request-dependent auth (including AWS SigV4).
+    auth: data.auth,
     authProfile: undefined, // TODO: Auth profile reference
     preRequestResult: data.preRequestResult,
     metadata: {

--- a/apps/ui/src/core/types/requests.ts
+++ b/apps/ui/src/core/types/requests.ts
@@ -134,7 +134,14 @@ export type APIKey = {
   in: "header" | "query";
 };
 
-type AuthType = "basic-auth" | "bearer-token" | "oauth" | "oauth2" | "none" | "api-key";
+type AuthType =
+  | "basic-auth"
+  | "bearer-token"
+  | "oauth"
+  | "oauth2"
+  | "none"
+  | "api-key"
+  | "aws-signature";
 
 export type Authorization = {
   enabled: boolean;

--- a/packages/executors/src/awsSigV4.ts
+++ b/packages/executors/src/awsSigV4.ts
@@ -1,0 +1,280 @@
+import { createHash, createHmac } from 'node:crypto'
+
+export interface AwsSigV4Config {
+  accessKey: string
+  secretKey: string
+  sessionToken?: string
+  region: string
+  /** AWS signing name, for example `execute-api`, `s3`, or `monitoring`. */
+  service: string
+}
+
+interface AwsSigV4Request {
+  method: string
+  /** Fully materialized absolute URL, retaining its original path and query encoding. */
+  url: string
+  headers: Record<string, string>
+  payload: Uint8Array
+  config: AwsSigV4Config
+  now?: Date
+}
+
+interface ParsedRawUrl {
+  host: string
+  path: string
+  query?: string
+}
+
+export interface AwsSigV4Result {
+  authorization: string
+  signedHeaders: string
+  signature: string
+}
+
+const ALGORITHM = 'AWS4-HMAC-SHA256'
+const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+function sha256(value: string | Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function hmac(key: string | Uint8Array, value: string): Buffer {
+  return createHmac('sha256', key).update(value).digest()
+}
+
+function awsEncode(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, char =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  )
+}
+
+function parseRawUrl(urlText: string): ParsedRawUrl {
+  // URL is used only for validation and authority parsing. Its pathname and
+  // searchParams are intentionally ignored because WHATWG URL normalizes dot
+  // segments and treats `+` as a space in query parameters.
+  const parsed = new URL(urlText)
+  const match = urlText.match(/^[a-z][a-z\d+.-]*:\/\/[^/?#]*([^?#]*)(?:\?([^#]*))?(?:#.*)?$/i)
+  if (!match) throw new Error('AWS SigV4 requires an absolute HTTP URL')
+  return {
+    host: parsed.host,
+    path: match[1] || '/',
+    query: match[2],
+  }
+}
+
+function normalizeStandardPath(rawPath: string): string {
+  const output: string[] = []
+  const hadTrailingSlash = rawPath.endsWith('/') || rawPath.endsWith('/.') || rawPath.endsWith('/..')
+  for (const segment of rawPath.split('/')) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      output.pop()
+      continue
+    }
+    output.push(segment)
+  }
+  const normalized = `/${output.join('/')}`
+  return hadTrailingSlash && normalized !== '/' ? `${normalized}/` : normalized
+}
+
+function encodeS3Path(rawPath: string): string {
+  let result = ''
+  for (let index = 0; index < rawPath.length;) {
+    const char = rawPath[index]
+    if (char === '/') {
+      result += '/'
+      index++
+      continue
+    }
+    const escape = rawPath.slice(index, index + 3)
+    if (/^%[\da-f]{2}$/i.test(escape)) {
+      result += escape.toUpperCase()
+      index += 3
+      continue
+    }
+    const codePoint = rawPath.codePointAt(index)
+    if (codePoint === undefined) break
+    const value = String.fromCodePoint(codePoint)
+    result += awsEncode(value)
+    index += value.length
+  }
+  return result || '/'
+}
+
+function isFetchNormalizedDotSegment(segment: string): boolean {
+  const decodedDots = segment.replace(/%2e/gi, '.')
+  return decodedDots === '.' || decodedDots === '..'
+}
+
+/**
+ * Reject S3 object-key paths that WHATWG fetch would silently rewrite.
+ * Duplicate slashes and non-dot percent escapes are safe and remain allowed.
+ */
+export function assertS3PathIsFetchSafe(url: string, service: string): void {
+  if (service !== 's3') return
+  const rawPath = parseRawUrl(url).path
+  if (rawPath.split('/').some(isFetchNormalizedDotSegment)) {
+    throw new Error(
+      'AWS SigV4 cannot send this S3 path safely: fetch normalizes dot-only path segments ' +
+      '(".", "..", and equivalent %2E forms) before sending, which would change the signed object key. ' +
+      'Use an S3 object key without dot-only path segments in this request pipeline.',
+    )
+  }
+}
+
+function canonicalPath(rawPath: string, service: string): string {
+  if (service === 's3') {
+    // S3 object keys are path-sensitive: preserve duplicate slashes, dot
+    // segments, and existing percent escapes (single URI encoding).
+    return encodeS3Path(rawPath)
+  }
+
+  // Other SigV4 services normalize path segments and double-encode existing
+  // percent escapes. Encoding the normalized raw text naturally turns `%2F`
+  // into `%252F`, while restoring only actual path separators.
+  return awsEncode(normalizeStandardPath(rawPath)).replace(/%2F/g, '/')
+}
+
+function decodePercentEncoding(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    // Preserve malformed escapes as literal percent signs. The secure executor
+    // will send the same raw query and AWS canonicalization encodes `%` as `%25`.
+    return value
+  }
+}
+
+function canonicalQuery(rawQuery: string | undefined): string {
+  if (rawQuery === undefined || rawQuery === '') return ''
+
+  const parameters = rawQuery.split('&').map(part => {
+    const separator = part.indexOf('=')
+    const rawKey = separator < 0 ? part : part.slice(0, separator)
+    const rawValue = separator < 0 ? '' : part.slice(separator + 1)
+    // Deliberately do not apply application/x-www-form-urlencoded semantics:
+    // a literal `+` is a plus byte, not a space.
+    return [
+      awsEncode(decodePercentEncoding(rawKey)),
+      awsEncode(decodePercentEncoding(rawValue)),
+    ] as const
+  })
+
+  parameters.sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+    leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : leftValue < rightValue ? -1 : leftValue > rightValue ? 1 : 0,
+  )
+  return parameters.map(([key, value]) => `${key}=${value}`).join('&')
+}
+
+function normalizeHeaderValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ')
+}
+
+function setHttpHeader(headers: Record<string, string>, name: string, value: string): void {
+  deleteHttpHeader(headers, name)
+  headers[name] = value
+}
+
+function deleteHttpHeader(headers: Record<string, string>, name: string): void {
+  const lowerName = name.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lowerName) delete headers[key]
+  }
+}
+
+function getHttpHeader(headers: Record<string, string>, name: string): string | undefined {
+  const lowerName = name.toLowerCase()
+  const key = Object.keys(headers).find(candidate => candidate.toLowerCase() === lowerName)
+  return key === undefined ? undefined : headers[key]
+}
+
+function formatAmzDate(date: Date): string {
+  if (Number.isNaN(date.getTime())) throw new Error('AWS SigV4 signing date is invalid')
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, '')
+}
+
+/** Internal canonicalization seam. Not exported from the package entry point. */
+export function createCanonicalRequest(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  payloadHash: string,
+  service: string,
+): { canonicalRequest: string; signedHeaders: string } {
+  const rawUrl = parseRawUrl(url)
+  const canonicalHeaderMap = new Map<string, string[]>()
+  const additionallySignedHeaders = new Set(['content-type', 'content-md5', 'date', 'range'])
+
+  for (const [name, value] of Object.entries(headers)) {
+    const lowerName = name.toLowerCase()
+    if (lowerName === 'host' || lowerName.startsWith('x-amz-') || additionallySignedHeaders.has(lowerName)) {
+      const values = canonicalHeaderMap.get(lowerName) ?? []
+      values.push(normalizeHeaderValue(value))
+      canonicalHeaderMap.set(lowerName, values)
+    }
+  }
+
+  const canonicalHeaderEntries = [...canonicalHeaderMap.entries()]
+    .map(([name, values]) => [name, values.join(',')] as const)
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+  const canonicalHeaders = canonicalHeaderEntries
+    .map(([name, value]) => `${name}:${value}\n`)
+    .join('')
+  const signedHeaders = canonicalHeaderEntries.map(([name]) => name).join(';')
+  const canonicalRequest = [
+    method.toUpperCase(),
+    canonicalPath(rawUrl.path, service),
+    canonicalQuery(rawUrl.query),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n')
+
+  return { canonicalRequest, signedHeaders }
+}
+
+/**
+ * Sign a fully materialized HTTP request using AWS Signature Version 4.
+ * Internal to the secure executor; the package entry point does not expose it.
+ */
+export function signAwsRequest(request: AwsSigV4Request): AwsSigV4Result {
+  const { method, headers, payload, config } = request
+  assertS3PathIsFetchSafe(request.url, config.service)
+  const rawUrl = parseRawUrl(request.url)
+  const now = request.now ?? new Date()
+  const amzDate = formatAmzDate(now)
+  const shortDate = amzDate.slice(0, 8)
+  const payloadHash = payload.byteLength === 0 ? EMPTY_SHA256 : sha256(payload)
+
+  const sessionToken = config.sessionToken || getHttpHeader(headers, 'X-Amz-Security-Token')
+  deleteHttpHeader(headers, 'Authorization')
+  setHttpHeader(headers, 'Host', rawUrl.host)
+  setHttpHeader(headers, 'X-Amz-Date', amzDate)
+  deleteHttpHeader(headers, 'X-Amz-Security-Token')
+  if (sessionToken !== undefined) {
+    setHttpHeader(headers, 'X-Amz-Security-Token', sessionToken)
+  }
+  if (config.service === 's3' || getHttpHeader(headers, 'X-Amz-Content-Sha256') !== undefined) {
+    setHttpHeader(headers, 'X-Amz-Content-Sha256', payloadHash)
+  }
+
+  const { canonicalRequest, signedHeaders } = createCanonicalRequest(
+    method,
+    request.url,
+    headers,
+    payloadHash,
+    config.service,
+  )
+  const credentialScope = `${shortDate}/${config.region}/${config.service}/aws4_request`
+  const stringToSign = [ALGORITHM, amzDate, credentialScope, sha256(canonicalRequest)].join('\n')
+  const dateKey = hmac(`AWS4${config.secretKey}`, shortDate)
+  const regionKey = hmac(dateKey, config.region)
+  const serviceKey = hmac(regionKey, config.service)
+  const signingKey = hmac(serviceKey, 'aws4_request')
+  const signature = hmac(signingKey, stringToSign).toString('hex')
+  const authorization = `${ALGORITHM} Credential=${config.accessKey}/${credentialScope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`
+  headers.Authorization = authorization
+
+  return { authorization, signedHeaders, signature }
+}

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -17,3 +17,4 @@ export * from './pipeline/index.js'
 
 export type { HeadlessEditor, RequestBuildHandler, ResponseProcessHandler } from './orchestrator.js'
 export { RequestOrchestrator, requestOrchestrator } from './orchestrator.js'
+export { mergeRequestHandlerResult } from './requestComposition.js'

--- a/packages/executors/src/index.ts
+++ b/packages/executors/src/index.ts
@@ -6,6 +6,9 @@ export { executeGrpc } from './grpc.js'
 export type { SecureRequestAdapter, SecureHandoffResult, SecureHttpResult, SecureRequestResult } from './secureRequest.js'
 export { executeSecureRequest, hasHttpHeader, deleteHttpHeader, addDefaultHttpHeaders, getFileMimeType } from './secureRequest.js'
 
+export type { SecureAuthProvider, SecureAuthApplyContext, SecureAuthApplyResult } from './secureAuthProviders/index.js'
+export { SecureAuthProviderRegistry, secureAuthProviders } from './secureAuthProviders/index.js'
+
 export {
   UnresolvedVariablesError,
   assertNoUnresolvedTemplates,

--- a/packages/executors/src/orchestrator.ts
+++ b/packages/executors/src/orchestrator.ts
@@ -11,6 +11,7 @@
 
 import { executeRequestPipeline } from './pipeline/executor.js'
 import type { PipelineResponse } from './pipeline/types.js'
+import { mergeRequestHandlerResult } from './requestComposition.js'
 
 export type HeadlessEditor = { getJSON(): any }
 
@@ -56,7 +57,7 @@ export class RequestOrchestrator {
     let request: any = {}
 
     for (const handler of this.requestHandlers) {
-      request = await handler(request, editor)
+      request = mergeRequestHandlerResult(request, await handler(request, editor))
     }
 
     if (!request?.url) {

--- a/packages/executors/src/pipeline/types.ts
+++ b/packages/executors/src/pipeline/types.ts
@@ -50,6 +50,12 @@ export enum PipelineStage {
 
 // ─── Request / response state ─────────────────────────────────────────────────
 
+export interface RequestAuth {
+  enabled?: boolean
+  type: string
+  config?: Record<string, unknown>
+}
+
 export interface RestApiRequestState {
   method: string
   url: string
@@ -60,6 +66,8 @@ export interface RestApiRequestState {
   contentType?: string
   bodyParams?: Array<{ key: string; value: string | File; type?: string; enabled?: boolean }>
   binary?: File | string | string[]
+  /** Raw auth configuration. Secrets may remain as templates until the secure executor resolves them. */
+  auth?: RequestAuth
   authProfile?: string
   preRequestResult?: any
   metadata?: Record<string, any>

--- a/packages/executors/src/requestComposition.ts
+++ b/packages/executors/src/requestComposition.ts
@@ -1,0 +1,12 @@
+/**
+ * Compose one plugin's request contribution without requiring every handler to
+ * spread fields produced by earlier plugins. Declared fields replace previous
+ * values as-is (including arrays); nullish results mean "no contribution".
+ */
+export function mergeRequestHandlerResult<T extends Record<string, unknown>>(
+  previous: T,
+  contribution: Partial<T> | Record<string, unknown> | null | undefined,
+): T {
+  if (contribution == null) return previous
+  return { ...previous, ...contribution }
+}

--- a/packages/executors/src/secureAuthProviders/awsSigV4Provider.ts
+++ b/packages/executors/src/secureAuthProviders/awsSigV4Provider.ts
@@ -1,0 +1,64 @@
+import { assertNoUnresolvedTemplates } from '../unresolvedVariables.js'
+import { assertS3PathIsFetchSafe, signAwsRequest, type AwsSigV4Config } from '../awsSigV4.js'
+import type { RequestAuth } from '../pipeline/types.js'
+import type { SecureAuthApplyContext, SecureAuthApplyResult, SecureAuthProvider } from './types.js'
+
+const AWS_SERVICE_ALIASES: Record<string, string> = {
+  cloudwatch: 'monitoring',
+}
+
+const SENSITIVE_HEADERS = ['Authorization', 'X-Amz-Security-Token']
+
+async function resolveConfig(
+  auth: RequestAuth,
+  resolveVar: (text: string) => Promise<string>,
+): Promise<AwsSigV4Config> {
+  const raw = (auth.config ?? {}) as Record<string, unknown>
+  const resolve = async (camelCase: string, snakeCase?: string): Promise<string> => {
+    const value = raw[camelCase] ?? (snakeCase ? raw[snakeCase] : undefined) ?? ''
+    return resolveVar(String(value))
+  }
+
+  const accessKey = (await resolve('accessKey', 'access_key')).trim()
+  const secretKey = (await resolve('secretKey', 'secret_key')).trim()
+  const sessionToken = (await resolve('sessionToken', 'session_token')).trim()
+  const region = (await resolve('region')).trim().toLowerCase()
+  const rawService = raw.service ?? raw.signingService ?? raw.signing_service ?? ''
+  const requestedService = (await resolveVar(String(rawService))).trim().toLowerCase()
+  const service = AWS_SERVICE_ALIASES[requestedService] ?? requestedService
+
+  assertNoUnresolvedTemplates([accessKey, secretKey, sessionToken, region, service])
+
+  const missing = [
+    !accessKey && 'access key',
+    !secretKey && 'secret key',
+    !region && 'region',
+    !service && 'signing service',
+  ].filter(Boolean)
+  if (missing.length > 0) {
+    throw new Error(`AWS SigV4 configuration is missing: ${missing.join(', ')}`)
+  }
+  return { accessKey, secretKey, sessionToken: sessionToken || undefined, region, service }
+}
+
+export const awsSigV4Provider: SecureAuthProvider = {
+  id: 'AWS SigV4',
+  authTypes: ['aws-signature', 'awsSignature'],
+  forcesManualRedirect: true,
+  supportsMultipartBody: false,
+  resolveConfig,
+  validateUrl(url, config) {
+    assertS3PathIsFetchSafe(url, (config as AwsSigV4Config).service)
+  },
+  apply(context: SecureAuthApplyContext): SecureAuthApplyResult {
+    signAwsRequest({
+      method: context.method,
+      url: context.url,
+      headers: context.headers,
+      payload: context.payload,
+      config: context.config as AwsSigV4Config,
+      now: context.now(),
+    })
+    return { redirect: 'manual', sensitiveHeaders: SENSITIVE_HEADERS }
+  },
+}

--- a/packages/executors/src/secureAuthProviders/index.ts
+++ b/packages/executors/src/secureAuthProviders/index.ts
@@ -1,0 +1,7 @@
+export type { SecureAuthProvider, SecureAuthApplyContext, SecureAuthApplyResult } from './types.js'
+export { SecureAuthProviderRegistry, secureAuthProviders } from './registry.js'
+
+import { secureAuthProviders } from './registry.js'
+import { awsSigV4Provider } from './awsSigV4Provider.js'
+
+secureAuthProviders.register(awsSigV4Provider)

--- a/packages/executors/src/secureAuthProviders/registry.ts
+++ b/packages/executors/src/secureAuthProviders/registry.ts
@@ -1,0 +1,24 @@
+import type { SecureAuthProvider } from './types.js'
+
+export class SecureAuthProviderRegistry {
+  private readonly providers = new Map<string, SecureAuthProvider>()
+
+  register(provider: SecureAuthProvider): void {
+    for (const authType of provider.authTypes) {
+      const existing = this.providers.get(authType)
+      if (existing) {
+        throw new Error(
+          `Secure auth provider for type "${authType}" is already registered (${existing.id}); cannot register ${provider.id}`,
+        )
+      }
+      this.providers.set(authType, provider)
+    }
+  }
+
+  getForAuthType(type: string | undefined): SecureAuthProvider | undefined {
+    return type ? this.providers.get(type) : undefined
+  }
+}
+
+/** Process-wide registry. Built-ins are registered as a side effect of importing './index.js'. */
+export const secureAuthProviders = new SecureAuthProviderRegistry()

--- a/packages/executors/src/secureAuthProviders/types.ts
+++ b/packages/executors/src/secureAuthProviders/types.ts
@@ -1,0 +1,59 @@
+import type { RequestAuth } from '../pipeline/types.js'
+
+/** Fully materialized outgoing request, right before it is sent. */
+export interface SecureAuthApplyContext {
+  method: string
+  url: string
+  /** Mutated in place by apply() — e.g. to set Authorization / X-Amz-Date. */
+  headers: Record<string, string>
+  payload: Uint8Array
+  /** Whatever this provider's resolveConfig() returned for this request. */
+  config: unknown
+  resolveVar: (text: string) => Promise<string>
+  now: () => Date
+}
+
+export interface SecureAuthApplyResult {
+  /**
+   * Force manual redirect handling for this response. NOTE: executeSecureRequest
+   * decides fetchOptions.redirect before apply() runs (driven by the static
+   * forcesManualRedirect flag), so this field is not currently consumed — it is
+   * reserved for a future per-request override, not dead code.
+   */
+  redirect?: 'manual'
+  /** Header names (case-insensitive) to redact as '[REDACTED]' in requestMeta.headers. */
+  sensitiveHeaders?: string[]
+}
+
+export interface SecureAuthProvider {
+  /** Human-readable id, also used in generic error messages (e.g. "AWS SigV4"). */
+  id: string
+  /** requestState.auth.type values this provider handles (aliases included). */
+  authTypes: string[]
+  /**
+   * True if a followed redirect could invalidate this provider's signature (changed
+   * host/path/query). When true, executeSecureRequest always uses redirect: 'manual'
+   * for requests using this provider, regardless of adapter.followRedirects.
+   * Defaults to false.
+   */
+  forcesManualRedirect?: boolean
+  /**
+   * False if this provider cannot sign a multipart/form-data body (no deterministic
+   * payload bytes). executeSecureRequest rejects such requests before building the
+   * FormData / reading files. Defaults to true.
+   */
+  supportsMultipartBody?: boolean
+  /**
+   * Resolve + validate this provider's config from requestState.auth (variable
+   * templates included). Runs once, right after the request body is materialized.
+   * Throw to fail the request before any body-building or network I/O.
+   */
+  resolveConfig(auth: RequestAuth, resolveVar: (text: string) => Promise<string>): Promise<unknown>
+  /**
+   * Optional pre-flight check against the final outgoing URL, run once right after
+   * the URL is materialized (before protocol handoff / body building).
+   */
+  validateUrl?(url: string, config: unknown): void
+  /** Sign / mutate the fully materialized request. Runs once, right before fetch. */
+  apply(context: SecureAuthApplyContext): SecureAuthApplyResult | Promise<SecureAuthApplyResult>
+}

--- a/packages/executors/src/secureRequest.ts
+++ b/packages/executors/src/secureRequest.ts
@@ -16,6 +16,7 @@ import type { RestApiRequestState } from './pipeline/types.js'
 import { executeWebSocket } from './websocket.js'
 import { executeGrpc } from './grpc.js'
 import { assertNoUnresolvedTemplates } from './unresolvedVariables.js'
+import { assertS3PathIsFetchSafe, signAwsRequest, type AwsSigV4Config } from './awsSigV4.js'
 
 // ─── Adapter interface ────────────────────────────────────────────────────────
 
@@ -38,6 +39,8 @@ export interface SecureRequestAdapter {
    * Defaults to true (Electron behaviour) when omitted.
    */
   isElectron?: boolean
+  /** Injectable clock for deterministic request signing tests. */
+  now?: () => Date
 }
 
 // ─── Result types ─────────────────────────────────────────────────────────────
@@ -113,6 +116,49 @@ export function getFileMimeType(filePath: string): string {
   return mimeTypes.lookup(filePath) || 'application/octet-stream'
 }
 
+const AWS_SERVICE_ALIASES: Record<string, string> = {
+  cloudwatch: 'monitoring',
+}
+
+function isAwsSigV4Auth(requestState: RestApiRequestState): boolean {
+  const auth = requestState.auth
+  return auth?.enabled !== false && (auth?.type === 'aws-signature' || auth?.type === 'awsSignature')
+}
+
+async function resolveAwsSigV4Config(
+  requestState: RestApiRequestState,
+  replaceVar: (text: string) => Promise<string>,
+): Promise<AwsSigV4Config | undefined> {
+  if (!isAwsSigV4Auth(requestState)) return undefined
+
+  const raw = requestState.auth?.config ?? {}
+  const resolve = async (camelCase: string, snakeCase?: string): Promise<string> => {
+    const value = raw[camelCase] ?? (snakeCase ? raw[snakeCase] : undefined) ?? ''
+    return replaceVar(String(value))
+  }
+
+  const accessKey = (await resolve('accessKey', 'access_key')).trim()
+  const secretKey = (await resolve('secretKey', 'secret_key')).trim()
+  const sessionToken = (await resolve('sessionToken', 'session_token')).trim()
+  const region = (await resolve('region')).trim().toLowerCase()
+  const rawService = raw.service ?? raw.signingService ?? raw.signing_service ?? ''
+  const requestedService = (await replaceVar(String(rawService))).trim().toLowerCase()
+  const service = AWS_SERVICE_ALIASES[requestedService] ?? requestedService
+
+  assertNoUnresolvedTemplates([accessKey, secretKey, sessionToken, region, service])
+
+  const missing = [
+    !accessKey && 'access key',
+    !secretKey && 'secret key',
+    !region && 'region',
+    !service && 'signing service',
+  ].filter(Boolean)
+  if (missing.length > 0) {
+    throw new Error(`AWS SigV4 configuration is missing: ${missing.join(', ')}`)
+  }
+  return { accessKey, secretKey, sessionToken: sessionToken || undefined, region, service }
+}
+
 function validateResolvedOutgoing(
   url: string,
   headers: Record<string, string>,
@@ -166,11 +212,13 @@ export async function executeSecureRequest(
 
   // ── 5. Replace variables in body text ────────────────────────────────────
   const body = requestState.body ? await rv(requestState.body) : undefined
+  const awsSigV4 = await resolveAwsSigV4Config(requestState, rv)
 
   // ── 6. Ensure URL has a protocol prefix ──────────────────────────────────
   if (!url.match(/^(https?|wss?|grpcs?):\/\//i)) url = `http://${url}`
 
   validateResolvedOutgoing(url, headers, body)
+  if (awsSigV4) assertS3PathIsFetchSafe(url, awsSigV4.service)
 
   // ── 7. Protocol detection — hand off WS / gRPC / GQL-sub to caller ───────
   const proto = new URL(url).protocol
@@ -258,19 +306,25 @@ export async function executeSecureRequest(
   const fetchOptions: any = {
     method: requestState.method || 'GET',
     headers,
-    redirect: followRedirects ? 'follow' : 'manual',
+    // A followed redirect can change host/path/query and invalidates SigV4.
+    // Re-signing redirect targets safely is out of scope, so signed requests
+    // always expose the redirect response to the caller.
+    redirect: awsSigV4 ? 'manual' : followRedirects ? 'follow' : 'manual',
   }
 
   // ── 9. Build request body ─────────────────────────────────────────────────
   if (requestState.binary) {
     if (Array.isArray(requestState.binary)) {
+      if (awsSigV4) {
+        throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+      }
       // Multiple binary files → send as multipart/form-data, one entry per file
       if (!adapter.readFile) throw new Error('Multi-file binary upload requires adapter.readFile')
       const formData = new FormData()
       for (const filePath of requestState.binary as string[]) {
         const fileBuffer = await adapter.readFile(filePath)
         const fileName = filePath.split('/').pop() ?? 'file'
-        const blob = new Blob([fileBuffer], { type: getFileMimeType(filePath) })
+        const blob = new Blob([Uint8Array.from(fileBuffer)], { type: getFileMimeType(filePath) })
         formData.append(fileName, blob, fileName)
       }
       fetchOptions.body = formData
@@ -293,6 +347,9 @@ export async function executeSecureRequest(
     const resolvedBodyParamTexts: string[] = []
 
     if (requestState.contentType === 'multipart/form-data') {
+      if (awsSigV4) {
+        throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+      }
       const formData = new FormData()
       for (const p of bodyParams) {
         if (p.enabled === false) continue
@@ -302,7 +359,7 @@ export async function executeSecureRequest(
           resolvedBodyParamTexts.push(filePath)
           const fileBuffer = await adapter.readFile(filePath)
           const fileName = filePath.split('/').pop() ?? 'file'
-          const blob = new Blob([fileBuffer], { type: getFileMimeType(filePath) })
+          const blob = new Blob([Uint8Array.from(fileBuffer)], { type: getFileMimeType(filePath) })
           formData.append(p.key, blob, fileName)
         } else if (p.type === 'text') {
           const resolvedValue = await rv(p.value as string)
@@ -343,6 +400,33 @@ export async function executeSecureRequest(
 
   // ── 11. Add default HTTP headers ──────────────────────────────────────────
   addDefaultHttpHeaders(headers, url)
+
+  // Auth injection intentionally happens here: URL/path/query/header variables
+  // and the exact outgoing body have all been materialized, but fetch has not
+  // started. This keeps signing in the secure executor rather than renderer hooks.
+  if (awsSigV4) {
+    const outgoingBody = fetchOptions.body
+    if (outgoingBody instanceof FormData) {
+      throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+    }
+    if (outgoingBody !== undefined && typeof outgoingBody !== 'string' && !ArrayBuffer.isView(outgoingBody)) {
+      throw new Error('AWS SigV4 requires a request body with deterministic bytes')
+    }
+    const payload = typeof outgoingBody === 'string'
+      ? Buffer.from(outgoingBody)
+      : outgoingBody === undefined
+        ? new Uint8Array()
+        : new Uint8Array(outgoingBody.buffer, outgoingBody.byteOffset, outgoingBody.byteLength)
+    signAwsRequest({
+      method: fetchOptions.method,
+      url,
+      headers,
+      payload,
+      config: awsSigV4,
+      now: adapter.now?.(),
+    })
+  }
+
   fetchOptions.headers = headers
 
   // ── 12. Execute HTTP request ──────────────────────────────────────────────
@@ -350,7 +434,13 @@ export async function executeSecureRequest(
   const buffer = response.body ? await response.arrayBuffer() : null
 
   // ── 13. Build request metadata for display ────────────────────────────────
-  const requestMetaHeaders = Object.entries(headers).map(([k, v]) => ({ key: k, value: v as string }))
+  const requestMetaHeaders = Object.entries(headers).map(([key, value]) => {
+    const lowerKey = key.toLowerCase()
+    const isSensitiveAwsHeader = awsSigV4 && (
+      lowerKey === 'authorization' || lowerKey === 'x-amz-security-token'
+    )
+    return { key, value: isSensitiveAwsHeader ? '[REDACTED]' : value as string }
+  })
   const isHttps = new URL(url).protocol === 'https:'
   const tlsInfo = isHttps
     ? { protocol: 'TLS 1.3', cipher: 'TLS_AES_128_GCM_SHA256', isSecure: true }

--- a/packages/executors/src/secureRequest.ts
+++ b/packages/executors/src/secureRequest.ts
@@ -16,7 +16,7 @@ import type { RestApiRequestState } from './pipeline/types.js'
 import { executeWebSocket } from './websocket.js'
 import { executeGrpc } from './grpc.js'
 import { assertNoUnresolvedTemplates } from './unresolvedVariables.js'
-import { assertS3PathIsFetchSafe, signAwsRequest, type AwsSigV4Config } from './awsSigV4.js'
+import { secureAuthProviders } from './secureAuthProviders/index.js'
 
 // ─── Adapter interface ────────────────────────────────────────────────────────
 
@@ -116,49 +116,6 @@ export function getFileMimeType(filePath: string): string {
   return mimeTypes.lookup(filePath) || 'application/octet-stream'
 }
 
-const AWS_SERVICE_ALIASES: Record<string, string> = {
-  cloudwatch: 'monitoring',
-}
-
-function isAwsSigV4Auth(requestState: RestApiRequestState): boolean {
-  const auth = requestState.auth
-  return auth?.enabled !== false && (auth?.type === 'aws-signature' || auth?.type === 'awsSignature')
-}
-
-async function resolveAwsSigV4Config(
-  requestState: RestApiRequestState,
-  replaceVar: (text: string) => Promise<string>,
-): Promise<AwsSigV4Config | undefined> {
-  if (!isAwsSigV4Auth(requestState)) return undefined
-
-  const raw = requestState.auth?.config ?? {}
-  const resolve = async (camelCase: string, snakeCase?: string): Promise<string> => {
-    const value = raw[camelCase] ?? (snakeCase ? raw[snakeCase] : undefined) ?? ''
-    return replaceVar(String(value))
-  }
-
-  const accessKey = (await resolve('accessKey', 'access_key')).trim()
-  const secretKey = (await resolve('secretKey', 'secret_key')).trim()
-  const sessionToken = (await resolve('sessionToken', 'session_token')).trim()
-  const region = (await resolve('region')).trim().toLowerCase()
-  const rawService = raw.service ?? raw.signingService ?? raw.signing_service ?? ''
-  const requestedService = (await replaceVar(String(rawService))).trim().toLowerCase()
-  const service = AWS_SERVICE_ALIASES[requestedService] ?? requestedService
-
-  assertNoUnresolvedTemplates([accessKey, secretKey, sessionToken, region, service])
-
-  const missing = [
-    !accessKey && 'access key',
-    !secretKey && 'secret key',
-    !region && 'region',
-    !service && 'signing service',
-  ].filter(Boolean)
-  if (missing.length > 0) {
-    throw new Error(`AWS SigV4 configuration is missing: ${missing.join(', ')}`)
-  }
-  return { accessKey, secretKey, sessionToken: sessionToken || undefined, region, service }
-}
-
 function validateResolvedOutgoing(
   url: string,
   headers: Record<string, string>,
@@ -212,13 +169,17 @@ export async function executeSecureRequest(
 
   // ── 5. Replace variables in body text ────────────────────────────────────
   const body = requestState.body ? await rv(requestState.body) : undefined
-  const awsSigV4 = await resolveAwsSigV4Config(requestState, rv)
+  const auth = requestState.auth
+  const authProvider = auth?.enabled !== false
+    ? secureAuthProviders.getForAuthType(auth?.type)
+    : undefined
+  const authConfig = authProvider && auth ? await authProvider.resolveConfig(auth, rv) : undefined
 
   // ── 6. Ensure URL has a protocol prefix ──────────────────────────────────
   if (!url.match(/^(https?|wss?|grpcs?):\/\//i)) url = `http://${url}`
 
   validateResolvedOutgoing(url, headers, body)
-  if (awsSigV4) assertS3PathIsFetchSafe(url, awsSigV4.service)
+  authProvider?.validateUrl?.(url, authConfig)
 
   // ── 7. Protocol detection — hand off WS / gRPC / GQL-sub to caller ───────
   const proto = new URL(url).protocol
@@ -306,17 +267,17 @@ export async function executeSecureRequest(
   const fetchOptions: any = {
     method: requestState.method || 'GET',
     headers,
-    // A followed redirect can change host/path/query and invalidates SigV4.
-    // Re-signing redirect targets safely is out of scope, so signed requests
-    // always expose the redirect response to the caller.
-    redirect: awsSigV4 ? 'manual' : followRedirects ? 'follow' : 'manual',
+    // A followed redirect can change host/path/query and invalidate a signed
+    // request. Re-signing redirect targets safely is out of scope, so requests
+    // using such a provider always expose the redirect response to the caller.
+    redirect: authProvider?.forcesManualRedirect ? 'manual' : followRedirects ? 'follow' : 'manual',
   }
 
   // ── 9. Build request body ─────────────────────────────────────────────────
   if (requestState.binary) {
     if (Array.isArray(requestState.binary)) {
-      if (awsSigV4) {
-        throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+      if (authProvider && authProvider.supportsMultipartBody === false) {
+        throw new Error(`${authProvider.id} does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable`)
       }
       // Multiple binary files → send as multipart/form-data, one entry per file
       if (!adapter.readFile) throw new Error('Multi-file binary upload requires adapter.readFile')
@@ -347,8 +308,8 @@ export async function executeSecureRequest(
     const resolvedBodyParamTexts: string[] = []
 
     if (requestState.contentType === 'multipart/form-data') {
-      if (awsSigV4) {
-        throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+      if (authProvider && authProvider.supportsMultipartBody === false) {
+        throw new Error(`${authProvider.id} does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable`)
       }
       const formData = new FormData()
       for (const p of bodyParams) {
@@ -404,27 +365,30 @@ export async function executeSecureRequest(
   // Auth injection intentionally happens here: URL/path/query/header variables
   // and the exact outgoing body have all been materialized, but fetch has not
   // started. This keeps signing in the secure executor rather than renderer hooks.
-  if (awsSigV4) {
+  let sensitiveHeaders: string[] = []
+  if (authProvider) {
     const outgoingBody = fetchOptions.body
-    if (outgoingBody instanceof FormData) {
-      throw new Error('AWS SigV4 does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable')
+    if (outgoingBody instanceof FormData && authProvider.supportsMultipartBody === false) {
+      throw new Error(`${authProvider.id} does not support multipart/form-data in this request pipeline because deterministic request bytes are unavailable`)
     }
     if (outgoingBody !== undefined && typeof outgoingBody !== 'string' && !ArrayBuffer.isView(outgoingBody)) {
-      throw new Error('AWS SigV4 requires a request body with deterministic bytes')
+      throw new Error(`${authProvider.id} requires a request body with deterministic bytes`)
     }
     const payload = typeof outgoingBody === 'string'
       ? Buffer.from(outgoingBody)
       : outgoingBody === undefined
         ? new Uint8Array()
         : new Uint8Array(outgoingBody.buffer, outgoingBody.byteOffset, outgoingBody.byteLength)
-    signAwsRequest({
+    const applyResult = await authProvider.apply({
       method: fetchOptions.method,
       url,
       headers,
       payload,
-      config: awsSigV4,
-      now: adapter.now?.(),
+      config: authConfig,
+      resolveVar: rv,
+      now: adapter.now ?? (() => new Date()),
     })
+    sensitiveHeaders = applyResult.sensitiveHeaders ?? []
   }
 
   fetchOptions.headers = headers
@@ -434,13 +398,11 @@ export async function executeSecureRequest(
   const buffer = response.body ? await response.arrayBuffer() : null
 
   // ── 13. Build request metadata for display ────────────────────────────────
-  const requestMetaHeaders = Object.entries(headers).map(([key, value]) => {
-    const lowerKey = key.toLowerCase()
-    const isSensitiveAwsHeader = awsSigV4 && (
-      lowerKey === 'authorization' || lowerKey === 'x-amz-security-token'
-    )
-    return { key, value: isSensitiveAwsHeader ? '[REDACTED]' : value as string }
-  })
+  const sensitiveHeaderNames = new Set(sensitiveHeaders.map(name => name.toLowerCase()))
+  const requestMetaHeaders = Object.entries(headers).map(([key, value]) => ({
+    key,
+    value: sensitiveHeaderNames.has(key.toLowerCase()) ? '[REDACTED]' : (value as string),
+  }))
   const isHttps = new URL(url).protocol === 'https:'
   const tlsInfo = isHttps
     ? { protocol: 'TLS 1.3', cipher: 'TLS_AES_128_GCM_SHA256', isSecure: true }

--- a/packages/executors/test/awsSigV4.test.ts
+++ b/packages/executors/test/awsSigV4.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { executeSecureRequest, type SecureRequestAdapter } from '../src/index.js'
+import {
+  createCanonicalRequest,
+  signAwsRequest,
+  type AwsSigV4Config,
+} from '../src/awsSigV4.js'
+
+const EMPTY_SHA256 = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+const OFFICIAL_TEST_CREDENTIALS: AwsSigV4Config = {
+  accessKey: 'AKIDEXAMPLE',
+  secretKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+  region: 'us-east-1',
+  service: 'service',
+}
+
+function successfulFetchResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+function signVector(
+  url: string,
+  expectedSignature: string,
+  options: { config?: AwsSigV4Config; headers?: Record<string, string> } = {},
+) {
+  const headers = options.headers ?? {}
+  const result = signAwsRequest({
+    method: 'GET',
+    url,
+    headers,
+    payload: new Uint8Array(),
+    config: options.config ?? OFFICIAL_TEST_CREDENTIALS,
+    now: new Date('2015-08-30T12:36:00Z'),
+  })
+  expect(result.signature).toBe(expectedSignature)
+  expect(headers.Authorization).toContain(`Signature=${expectedSignature}`)
+}
+
+describe('AWS Signature Version 4', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // AWS CRT suite: awslabs/aws-c-auth/tests/aws-signing-test-suite/v4
+  it.each([
+    ['get-vanilla', 'https://example.amazonaws.com/', '5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31'],
+    ['get-utf8', 'https://example.amazonaws.com/ሴ', '8318018e0b0f223aa2bbf98705b62bb787dc9c0e678f255a891fd03141be5d85'],
+    ['get-slash-dot-slash-normalized', 'https://example.amazonaws.com/./', '5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31'],
+    ['get-relative-normalized', 'https://example.amazonaws.com/example/..', '5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31'],
+    ['get-slashes-normalized', 'https://example.amazonaws.com//example//', '9a624bd73a37c9a373b5312afbebe7a714a789de108f0bdfe846570885f57e84'],
+    ['get-space-normalized', 'https://example.amazonaws.com/example space/', '652487583200325589f1fba4c7e578f72c47cb61beeca81406b39ddec1366741'],
+    ['get-vanilla-query-order-key-case', 'https://example.amazonaws.com/?Param2=value2&Param1=value1', 'b97d918cfa904a5beff61c982a1b6f458b799221646efd99d3219ec94cdf2500'],
+    ['get-vanilla-query-order-encoded', 'https://example.amazonaws.com/?Param-3=Value3&Param=Value2&%E1%88%B4=Value1', '371d3713e185cc334048618a97f809c9ffe339c62934c032af5a0e595648fcac'],
+  ])('matches official vector %s', (_name, url, signature) => {
+    signVector(url, signature)
+  })
+
+  it('matches the official session-token vector', () => {
+    signVector(
+      'https://example.amazonaws.com/',
+      '07ec1639c89043aa0e3e2de82b96708f198cceab042d4a97044c66dd9f74e7f8',
+      {
+        config: {
+          ...OFFICIAL_TEST_CREDENTIALS,
+          sessionToken: '6e86291e8372ff2a2260956d9b8aae1d763fbf315fa00fa31553b73ebf194267',
+        },
+      },
+    )
+  })
+
+  it('adopts an imported security-token header when auth config has no session token', () => {
+    const headers = {
+      'x-AMZ-security-TOKEN': '6e86291e8372ff2a2260956d9b8aae1d763fbf315fa00fa31553b73ebf194267',
+    }
+
+    signVector(
+      'https://example.amazonaws.com/',
+      '07ec1639c89043aa0e3e2de82b96708f198cceab042d4a97044c66dd9f74e7f8',
+      { headers },
+    )
+
+    expect(headers).toHaveProperty(
+      'X-Amz-Security-Token',
+      '6e86291e8372ff2a2260956d9b8aae1d763fbf315fa00fa31553b73ebf194267',
+    )
+    expect(Object.keys(headers).filter(name => name.toLowerCase() === 'x-amz-security-token'))
+      .toEqual(['X-Amz-Security-Token'])
+    expect(headers).toHaveProperty(
+      'Authorization',
+      expect.stringContaining('SignedHeaders=host;x-amz-date;x-amz-security-token'),
+    )
+  })
+
+  // AWS S3 documentation, "Example: GET Object".
+  it('matches the official S3 GET Object vector', () => {
+    const headers: Record<string, string> = { Range: 'bytes=0-9' }
+    const result = signAwsRequest({
+      method: 'GET',
+      url: 'https://examplebucket.s3.amazonaws.com/test.txt',
+      headers,
+      payload: new Uint8Array(),
+      config: {
+        accessKey: 'AKIAIOSFODNN7EXAMPLE',
+        secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        region: 'us-east-1',
+        service: 's3',
+      },
+      now: new Date('2013-05-24T00:00:00Z'),
+    })
+
+    expect(result.signedHeaders).toBe('host;range;x-amz-content-sha256;x-amz-date')
+    expect(result.signature).toBe('f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41')
+  })
+
+  it('uses normalized, double-encoded paths for standard services', () => {
+    const { canonicalRequest } = createCanonicalRequest(
+      'GET',
+      'https://example.amazonaws.com/a//./b/../%2F/%252F',
+      { Host: 'example.amazonaws.com' },
+      EMPTY_SHA256,
+      'execute-api',
+    )
+
+    expect(canonicalRequest.split('\n')[1]).toBe('/a/%252F/%25252F')
+  })
+
+  it('preserves S3 slash, dot-segment, and percent-escape semantics', () => {
+    const { canonicalRequest } = createCanonicalRequest(
+      'GET',
+      'https://examplebucket.s3.amazonaws.com/a//./b/../%2F/%252F',
+      { Host: 'examplebucket.s3.amazonaws.com' },
+      EMPTY_SHA256,
+      's3',
+    )
+
+    expect(canonicalRequest.split('\n')[1]).toBe('/a//./b/../%2F/%252F')
+  })
+
+  it.each([
+    '/bucket/./object',
+    '/bucket/../object',
+    '/bucket/%2e/object',
+    '/bucket/.%2E/object',
+    '/bucket/%2e./object',
+    '/bucket/%2E%2e/object',
+  ])('rejects an S3 fetch-normalized dot path before signing or fetch: %s', async path => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(executeSecureRequest({
+      method: 'GET',
+      url: `https://examplebucket.s3.amazonaws.com${path}`,
+      headers: [], queryParams: [], pathParams: [],
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: { ...OFFICIAL_TEST_CREDENTIALS, service: 's3' },
+      },
+    }, { replaceVar: async text => text, isElectron: false })).rejects.toThrow(
+      'fetch normalizes dot-only path segments',
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unsafe S3 path before mutating signing headers', () => {
+    const headers: Record<string, string> = {}
+
+    expect(() => signAwsRequest({
+      method: 'GET',
+      url: 'https://examplebucket.s3.amazonaws.com/bucket/%2E%2e/object',
+      headers,
+      payload: new Uint8Array(),
+      config: { ...OFFICIAL_TEST_CREDENTIALS, service: 's3' },
+      now: new Date('2015-08-30T12:36:00Z'),
+    })).toThrow('fetch normalizes dot-only path segments')
+
+    expect(headers).toEqual({})
+  })
+
+  it('allows S3 duplicate slashes and non-dot escapes to be signed and fetched', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    await executeSecureRequest({
+      method: 'GET',
+      url: 'https://examplebucket.s3.amazonaws.com/bucket//folder/%2F/object',
+      headers: [], queryParams: [], pathParams: [],
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: { ...OFFICIAL_TEST_CREDENTIALS, service: 's3' },
+      },
+    }, {
+      replaceVar: async text => text,
+      now: () => new Date('2015-08-30T12:36:00Z'),
+      isElectron: false,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('https://examplebucket.s3.amazonaws.com/bucket//folder/%2F/object')
+    expect(options.redirect).toBe('manual')
+    expect((options.headers as Record<string, string>).Authorization).toContain(
+      'Credential=AKIDEXAMPLE/20150830/us-east-1/s3/aws4_request',
+    )
+  })
+
+  it('canonicalizes raw query bytes without treating plus as space', () => {
+    const { canonicalRequest } = createCanonicalRequest(
+      'GET',
+      'https://example.amazonaws.com/?literal=+&encoded=%2B&double=%252B&space=%20&repeat=b&repeat=a&empty=&novalue&=blank',
+      { Host: 'example.amazonaws.com' },
+      EMPTY_SHA256,
+      'execute-api',
+    )
+
+    expect(canonicalRequest.split('\n')[2]).toBe(
+      '=blank&double=%252B&empty=&encoded=%2B&literal=%2B&novalue=&repeat=a&repeat=b&space=%20',
+    )
+  })
+
+  it('signs only after variables, path, query, headers, and body are materialized', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const adapter: SecureRequestAdapter = {
+      replaceVar: async text => text
+        .replaceAll('{{HOST}}', 'example.amazonaws.com')
+        .replaceAll('{{ID}}', 'a/b')
+        .replaceAll('{{VALUE}}', 'hello world')
+        .replaceAll('{{ACCESS}}', 'AKIDEXAMPLE')
+        .replaceAll('{{SECRET}}', OFFICIAL_TEST_CREDENTIALS.secretKey),
+      now: () => new Date('2015-08-30T12:36:00Z'),
+      followRedirects: true,
+      isElectron: false,
+    }
+
+    const result = await executeSecureRequest({
+      method: 'POST',
+      url: 'https://{{HOST}}/items/{id}',
+      headers: [
+        { key: 'Content-Type', value: 'application/json', enabled: true },
+        { key: 'X-Amz-Target', value: 'Example.{{VALUE}}', enabled: true },
+        { key: 'authorization', value: 'obsolete', enabled: true },
+        { key: 'x-AMZ-date', value: '20000101T000000Z', enabled: true },
+        { key: 'X-Amz-Security-Token', value: 'obsolete-token', enabled: true },
+      ],
+      queryParams: [{ key: 'q', value: '{{VALUE}}', enabled: true }],
+      pathParams: [{ key: 'id', value: '{{ID}}', enabled: true }],
+      body: '{"message":"{{VALUE}}"}',
+      contentType: 'application/json',
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: {
+          accessKey: '{{ACCESS}}',
+          secretKey: '{{SECRET}}',
+          sessionToken: 'session-token',
+          region: 'us-east-1',
+          service: 'execute-api',
+        },
+      },
+    }, adapter)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const sentHeaders = options.headers as Record<string, string>
+    expect(url).toBe('https://example.amazonaws.com/items/a%2Fb?q=hello%20world')
+    expect(options.body).toBe('{"message":"hello world"}')
+    expect(options.redirect).toBe('manual')
+    expect(sentHeaders['X-Amz-Date']).toBe('20150830T123600Z')
+    expect(sentHeaders['X-Amz-Security-Token']).toBe('session-token')
+    expect(sentHeaders.Authorization).toContain('Credential=AKIDEXAMPLE/20150830/us-east-1/execute-api/aws4_request')
+    expect(sentHeaders.Authorization).toContain('SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target')
+    expect(Object.keys(sentHeaders).filter(key => key.toLowerCase() === 'authorization')).toEqual(['Authorization'])
+    expect(Object.keys(sentHeaders).filter(key => key.toLowerCase() === 'x-amz-date')).toEqual(['X-Amz-Date'])
+    expect(Object.keys(sentHeaders).filter(key => key.toLowerCase() === 'x-amz-security-token')).toEqual(['X-Amz-Security-Token'])
+    expect(result.kind).toBe('http')
+    if (result.kind === 'http') {
+      expect(result.requestMeta.headers).toEqual(expect.arrayContaining([
+        { key: 'Authorization', value: '[REDACTED]' },
+        { key: 'X-Amz-Security-Token', value: '[REDACTED]' },
+      ]))
+    }
+  })
+
+  it('preserves and redacts an imported security-token header through secure execution', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeSecureRequest({
+      method: 'GET',
+      url: 'https://example.amazonaws.com/',
+      headers: [{
+        key: 'x-AMZ-security-TOKEN',
+        value: 'imported-session-token',
+        enabled: true,
+      }],
+      queryParams: [],
+      pathParams: [],
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: { ...OFFICIAL_TEST_CREDENTIALS, service: 'execute-api' },
+      },
+    }, {
+      replaceVar: async text => text,
+      now: () => new Date('2015-08-30T12:36:00Z'),
+      isElectron: false,
+    })
+
+    const sentHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>
+    expect(sentHeaders['X-Amz-Security-Token']).toBe('imported-session-token')
+    expect(sentHeaders.Authorization).toContain(
+      'SignedHeaders=host;x-amz-date;x-amz-security-token',
+    )
+    expect(Object.keys(sentHeaders).filter(name => name.toLowerCase() === 'x-amz-security-token'))
+      .toEqual(['X-Amz-Security-Token'])
+    expect(result.kind).toBe('http')
+    if (result.kind === 'http') {
+      expect(result.requestMeta.headers).toContainEqual({
+        key: 'X-Amz-Security-Token',
+        value: '[REDACTED]',
+      })
+    }
+  })
+
+  it('fails before fetch when required signing configuration is missing', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(executeSecureRequest({
+      method: 'GET',
+      url: 'https://example.amazonaws.com',
+      headers: [], queryParams: [], pathParams: [],
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: { accessKey: '', secretKey: '', region: '', service: '' },
+      },
+    }, { replaceVar: async text => text, isElectron: false })).rejects.toThrow(
+      'AWS SigV4 configuration is missing: access key, secret key, region, signing service',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects multipart signing because deterministic bytes are unavailable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(executeSecureRequest({
+      method: 'POST',
+      url: 'https://s3.us-east-1.amazonaws.com/example',
+      headers: [], queryParams: [], pathParams: [],
+      contentType: 'multipart/form-data',
+      bodyParams: [{ key: 'field', value: 'value', type: 'text', enabled: true }],
+      auth: {
+        enabled: true,
+        type: 'aws-signature',
+        config: { ...OFFICIAL_TEST_CREDENTIALS, service: 's3' },
+      },
+    }, { replaceVar: async text => text, isElectron: false })).rejects.toThrow(
+      'AWS SigV4 does not support multipart/form-data in this request pipeline',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/executors/test/requestComposition.test.ts
+++ b/packages/executors/test/requestComposition.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { mergeRequestHandlerResult } from '../src/requestComposition.js'
+
+type Handler = (request: Record<string, unknown>) => Record<string, unknown> | null | undefined
+
+function runHandlers(handlers: Handler[]): Record<string, unknown> {
+  return handlers.reduce(
+    (request, handler) => mergeRequestHandlerResult(request, handler(request)),
+    {},
+  )
+}
+
+const authHandler: Handler = request => ({
+  ...request,
+  auth: {
+    enabled: true,
+    type: 'aws-signature',
+    config: { region: 'us-east-1', service: 'execute-api' },
+  },
+})
+
+const restHandlerReturningFreshObject: Handler = () => ({
+  method: 'GET',
+  url: 'https://example.amazonaws.com/resource',
+  headers: [{ key: 'Accept', value: 'application/json' }],
+})
+
+describe('request handler composition', () => {
+  it.each([
+    ['auth then REST', [authHandler, restHandlerReturningFreshObject]],
+    ['REST then auth', [restHandlerReturningFreshObject, authHandler]],
+  ])('preserves auth in the final request for %s registration order', (_name, handlers) => {
+    expect(runHandlers(handlers).auth).toEqual({
+      enabled: true,
+      type: 'aws-signature',
+      config: { region: 'us-east-1', service: 'execute-api' },
+    })
+  })
+
+  it('uses a declared array contribution without concatenating prior entries', () => {
+    const previous = { headers: [{ key: 'First', value: 'one' }], auth: { type: 'aws-signature' } }
+    const contribution = { headers: [{ key: 'Final', value: 'two' }] }
+
+    expect(mergeRequestHandlerResult(previous, contribution)).toEqual({
+      headers: [{ key: 'Final', value: 'two' }],
+      auth: { type: 'aws-signature' },
+    })
+  })
+
+  it.each([null, undefined])('treats a %s handler result as no contribution', result => {
+    const previous = { method: 'GET', auth: { type: 'aws-signature' } }
+
+    expect(mergeRequestHandlerResult(previous, result)).toBe(previous)
+  })
+})

--- a/packages/executors/test/secureAuthProviders.test.ts
+++ b/packages/executors/test/secureAuthProviders.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { executeSecureRequest, secureAuthProviders, SecureAuthProviderRegistry, type SecureAuthProvider } from '../src/index.js'
+
+function successfulFetchResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    arrayBuffer: async () => new ArrayBuffer(0),
+  }
+}
+
+describe('secureAuthProviders registry', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('getForAuthType returns undefined for an unknown type', () => {
+    expect(secureAuthProviders.getForAuthType('does-not-exist')).toBeUndefined()
+  })
+
+  it('getForAuthType returns the registered provider for each of its authTypes aliases', () => {
+    expect(secureAuthProviders.getForAuthType('aws-signature')?.id).toBe('AWS SigV4')
+    expect(secureAuthProviders.getForAuthType('awsSignature')?.id).toBe('AWS SigV4')
+  })
+
+  it('register throws on a duplicate authTypes entry', () => {
+    const registry = new SecureAuthProviderRegistry()
+    const stubA: SecureAuthProvider = {
+      id: 'Stub A',
+      authTypes: ['stub'],
+      resolveConfig: async () => undefined,
+      apply: () => ({}),
+    }
+    const stubB: SecureAuthProvider = {
+      id: 'Stub B',
+      authTypes: ['stub'],
+      resolveConfig: async () => undefined,
+      apply: () => ({}),
+    }
+    registry.register(stubA)
+    expect(() => registry.register(stubB)).toThrow(/Stub A/)
+    expect(() => registry.register(stubB)).toThrow(/Stub B/)
+  })
+
+  it('a provider with supportsMultipartBody unset behaves as true (permissive default)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(successfulFetchResponse()))
+
+    const stub: SecureAuthProvider = {
+      id: 'Stub Permissive Multipart',
+      authTypes: ['stub-multipart-permissive'],
+      resolveConfig: async () => ({}),
+      apply: () => ({}),
+    }
+    secureAuthProviders.register(stub)
+
+    let thrown: unknown
+    try {
+      await executeSecureRequest({
+        method: 'POST',
+        url: 'https://example.com/upload',
+        headers: [], queryParams: [], pathParams: [],
+        contentType: 'multipart/form-data',
+        bodyParams: [{ key: 'field', value: 'value', type: 'text', enabled: true }],
+        auth: { enabled: true, type: 'stub-multipart-permissive', config: {} },
+      }, { replaceVar: async text => text, isElectron: false })
+    } catch (err) {
+      thrown = err
+    }
+
+    // The permissive default must not take the "does not support multipart/form-data"
+    // fail-fast path (neither the early body-building guard nor the pre-signing one).
+    if (thrown) {
+      expect((thrown as Error).message).not.toContain('does not support multipart/form-data')
+    }
+  })
+
+  it('a provider with forcesManualRedirect unset behaves as false (follows adapter.followRedirects)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const stub: SecureAuthProvider = {
+      id: 'Stub No Redirect Force',
+      authTypes: ['stub-no-redirect-force'],
+      resolveConfig: async () => ({}),
+      apply: () => ({}),
+    }
+    secureAuthProviders.register(stub)
+
+    await executeSecureRequest({
+      method: 'GET',
+      url: 'https://example.com/',
+      headers: [], queryParams: [], pathParams: [],
+      auth: { enabled: true, type: 'stub-no-redirect-force', config: {} },
+    }, { replaceVar: async text => text, isElectron: false, followRedirects: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(options.redirect).toBe('follow')
+  })
+
+  it('an unrecognized auth.type is a no-op, not an error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    await executeSecureRequest({
+      method: 'GET',
+      url: 'https://example.com/',
+      headers: [{ key: 'X-Existing', value: 'unchanged', enabled: true }],
+      queryParams: [], pathParams: [],
+      auth: { enabled: true, type: 'basic', config: { username: 'u', password: 'p' } },
+    }, { replaceVar: async text => text, isElectron: false })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const sentHeaders = options.headers as Record<string, string>
+    expect(sentHeaders['X-Existing']).toBe('unchanged')
+    expect(sentHeaders.Authorization).toBeUndefined()
+  })
+
+  it('auth.enabled === false bypasses the provider even when type matches', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(successfulFetchResponse())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await executeSecureRequest({
+      method: 'GET',
+      url: 'https://example.amazonaws.com/',
+      headers: [], queryParams: [], pathParams: [],
+      auth: {
+        enabled: false,
+        type: 'aws-signature',
+        config: {
+          accessKey: 'AKIDEXAMPLE',
+          secretKey: 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+          region: 'us-east-1',
+          service: 'execute-api',
+        },
+      },
+    }, { replaceVar: async text => text, isElectron: false })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const sentHeaders = options.headers as Record<string, string>
+    expect(sentHeaders.Authorization).toBeUndefined()
+    expect(result.kind).toBe('http')
+    if (result.kind === 'http') {
+      expect(result.requestMeta.headers.find(h => h.key === 'Authorization')).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add AWS Signature Version 4 signing to the shared secure request executor
- resolve credentials and sign only after URL, query, headers, and payload bytes are materialized
- support temporary credentials, environment variables, and AWS signing-service aliases
- preserve auth contributions regardless of plugin registration order
- force manual redirects for signed requests and reject request shapes that cannot be signed safely

## Supported services

S3, API Gateway (`execute-api` and `apigateway`), Lambda, DynamoDB, IAM, CloudWatch (`monitoring`), SNS, and SQS. Custom AWS signing names remain supported so the signer does not require core changes for every service.

## Safety and compatibility

- signing remains in the secure executor rather than renderer hooks
- `Authorization` and `X-Amz-Security-Token` are redacted from request metadata
- stale AWS signing headers are normalized and replaced
- imported `X-Amz-Security-Token` headers are adopted when no token is present in auth config
- signed redirects use `manual` mode to avoid leaking credentials or invalidating signatures
- multipart signing is rejected because the pipeline cannot guarantee deterministic bytes
- S3 dot-only path segments are rejected because WHATWG `fetch` would normalize them after signing

## Tests

- 26 SigV4 tests, including AWS CRT vectors, an official S3 vector, query/path encoding, temporary credentials, binary payloads, redirects, and unsafe request rejection
- 5 request-composition tests covering both plugin registration orders
- 9 focused UI/request-engine tests
- `tsc -p packages/executors/tsconfig.json --noEmit`
- `git diff --check`

## Related PR

A companion PR in `VoidenHQ/plugin-voiden-advanced-auth` exposes the configuration in the auth block and transports it through the headless runner.

Closes #517
