### PR TITLE
fix: highlight only the current File Explorer selection

### DIFF
--- a/apps/ui/src/core/file-system/components/FileSystemList.tsx
+++ b/apps/ui/src/core/file-system/components/FileSystemList.tsx
@@ -612,21 +612,21 @@ export const FileSystemList = () => {
   }, [treeData, tryStartDuplicateRename]);
 
   useEffect(() => {
+    const tree = treeRef.current;
+    if (!tree) return;
+
     if (!activeFile?.source) {
-      const tree = treeRef.current;
-      if (!tree) return;
       const { anchor, mostRecent } = tree.state.nodes.selection;
       tree.setSelection({ ids: [], anchor, mostRecent });
       return;
     }
 
     const source = activeFile.source;
+    tree.setSelection({ ids: [source], anchor: source, mostRecent: source });
+
     let cancelled = false;
 
-    const expandAndSelect = async () => {
-      const tree = treeRef.current;
-      if (!tree) return;
-
+    const expandAndScroll = async () => {
       const ancestors: string[] = [];
       let cursor = getParentPath(source);
       while (cursor) {
@@ -661,11 +661,11 @@ export const FileSystemList = () => {
 
       setTimeout(() => {
         if (cancelled) return;
-        treeRef.current?.select(source, { align: "auto", focus: false });
+        treeRef.current?.scrollTo(source, "auto");
       }, 50);
     };
 
-    expandAndSelect();
+    expandAndScroll();
 
     return () => {
       cancelled = true;

--- a/apps/ui/src/core/file-system/components/FileSystemList/TreeNode.tsx
+++ b/apps/ui/src/core/file-system/components/FileSystemList/TreeNode.tsx
@@ -447,7 +447,6 @@ export function TreeNode({
 
   const nameClass = getNameClass(node.data, activeFile);
   const showCollapseAll = node.data.type === "folder" && hasOpenDescendant(node);
-  const isActiveFile = activeFile?.source === node.data.path;
   const isRangeSelected = node.isSelected && node.tree.selectedNodes.length > 1;
 
   return (
@@ -456,16 +455,15 @@ export function TreeNode({
       ref={dragHandle}
       className={cn(
         "group h-[22px] overflow-hidden transition-colors border border-transparent",
-        !isDragOver && !isActiveFile && !node.isSelected && "hover:bg-hover",
+        !isDragOver && !node.isSelected && "hover:bg-hover",
         isContextMenuOpen && "border-active",
-        isActiveFile && !isRangeSelected && !isDragOver && "bg-active",
         // Selection stays visible (background) even after focus moves away
         // (e.g. clicking into the editor) — a border is added only while
         // this row is still the actually-focused selection, so the two
         // states ("selected" vs "selected AND focused") read differently,
         // matching Cursor's sidebar.
-        node.isSelected && !isRangeSelected && !isActiveFile && !isDragOver && "bg-active",
-        node.isSelected && !isRangeSelected && node.isFocused && !isActiveFile && !isDragOver && "border-border",
+        node.isSelected && !isRangeSelected && !isDragOver && "bg-active",
+        node.isSelected && !isRangeSelected && node.isFocused && !isDragOver && "border-border",
         isRangeSelected && !isDragOver && "bg-accent/20",
         node.isFocused && !isDragOver && "ring-0",
         (isDragOver || isInternalDropTargetFolder) && `bg-accent/30 ${node.data.type === "folder" ? "border-l-2 border-accent" : ""}`,


### PR DESCRIPTION
## Problem

Follow-up to #530, which fixed half of #528. That PR made the tree selection follow the active document, but not the reverse — selecting a row never changes the active document, so the two highlight sources could still both be lit at once:

- **Open a file, then click its containing folder** → the folder is highlighted via `node.isSelected` and the file is still highlighted via `activeFile.source`. Two rows lit.

Reported by @davinder-sudo  in https://github.com/VoidenHQ/voiden/issues/528#issuecomment-5315433317.

## Fix

Make the tree selection the single source of the highlight.

**`TreeNode.tsx`** — drop the `activeFile`-driven background entirely, so rows style off `node.isSelected` alone. The active document still drives the selection, so opening a file lights its row exactly as before; clicking a folder moves the selection and the file row goes dark.

**`FileSystemList.tsx`** — set the selection with `setSelection` instead of a deferred `select()`. `setSelection` writes `ids`, `anchor` and `mostRecent` and nothing else, which means:

- the row lights on the same tick as the tab switch instead of 50ms later;
- `scrollTo(source, "auto")` returns to its original form, so scroll behaviour is unchanged;
- no `focus` dispatch at all, so the `focus: false` flag is no longer needed — `select()` would otherwise dispatch focus, and `row-container.js` calls `el.current.focus()` on the focused row, which would pull keyboard focus out of the editor on every tab switch;
- it stays off `select()`'s discarded `scrollTo` promise, which `waitFor` bare-`reject()`s after ~1s.

Clearing on no active document still preserves the anchor, for the reason established in #530 — `deselectAll()` nulls it, and `selectContiguous()` (Shift+click) has no range to select without one.

## Note for review

With the highlight purely selection-driven, once you click a folder there is no remaining indicator of which file is open in the editor. That is the literal reading of "only the current selection should be highlighted at a time", but it is a product call worth confirming — VS Code keeps a faint marker on the open file. Happy to add a subtler active-file treatment instead if you'd prefer that.

## Testing

Verified manually in the running app:

- Open a file, then click its containing folder → only the folder is highlighted.
- Switch tabs from the tab bar → exactly one row lit, and it moves instantly.
- Close all tabs → no row highlighted.
- Shift+click right after opening a file → full range selected, uniform shade across files and folders.
- Cmd+click scattered files → uniform shade.
- Typing in the editor is not intercepted by the tree.

`tsc --noEmit` and `eslint` on `apps/ui`: no new errors from this change.

Fixes #528
