### PR TITLE
fix: keep file rename input within sidebar

### DIFF
--- a/apps/ui/src/core/file-system/components/FileSystemList/RenameInput.tsx
+++ b/apps/ui/src/core/file-system/components/FileSystemList/RenameInput.tsx
@@ -21,7 +21,7 @@ export function RenameInput({ node, error, setError, onSubmit, setIsRenaming }: 
   }, [node.data.name, setIsRenaming]);
 
   return (
-    <div className="flex flex-col flex-1">
+    <div className="flex min-w-0 flex-1 flex-col">
       <input
         autoFocus
         ref={inputRef}
@@ -44,7 +44,7 @@ export function RenameInput({ node, error, setError, onSubmit, setIsRenaming }: 
           }
         }}
         onClick={(e) => e.stopPropagation()}
-        className={`px-1 py-0 border rounded h-5 bg-stone-800 text-stone-200 focus:outline-none focus:ring-1 ${error ? "border-red-500 focus:ring-red-500" : "border-stone-700 focus:ring-orange-500"
+        className={`w-full min-w-0 max-w-full box-border px-1 py-0 border rounded h-5 bg-stone-800 text-stone-200 focus:outline-none focus:ring-1 ${error ? "border-red-500 focus:ring-red-500" : "border-stone-700 focus:ring-orange-500"
           }`}
       />
       {error && <span className="bg-red-500 text-xs text-white absolute top-7 left-12 p-1 rounded z-10">{error}</span>}


### PR DESCRIPTION
## What changed

- Keep the File Explorer rename input within the available row width while the sidebar is resized.
- Allow long filenames to remain editable without shifting the tree contents horizontally.

## Why

The rename wrapper and input retained an intrinsic minimum width. When a long filename was being edited while the sidebar narrowed, the input could overflow its row and move the File Explorer contents sideways.

## Validation

- Refreshed the branch from the latest `upstream/beta` before committing.
- `git diff --cached --check`
- Manual sidebar resize verification passes.

Follow-up to #532.
