### PR TITLE
feat: support optional unresolved request fields

### DIFF
--- a/apps/ui/src/__test__/plugincontext.test.ts
+++ b/apps/ui/src/__test__/plugincontext.test.ts
@@ -81,6 +81,7 @@ vi.mock('@/core/editors/voiden/VoidenEditor', () => ({
     getState: vi.fn(),
   },
   proseClasses: ['prose', 'prose-sm'],
+  previewProseClasses: 'prose prose-sm text-preview',
 }));
 
 vi.mock('@/core/editors/code/CodeEditorStore', () => ({
@@ -468,7 +469,12 @@ describe('createPlugin', () => {
 
       const { sidebar } = usePluginStore.getState();
       expect(sidebar.left).toHaveLength(1);
-      expect(sidebar.left[0]).toEqual(testTab);
+      expect(sidebar.left[0]).toMatchObject({
+        id: testTab.id,
+        title: testTab.title,
+        component: expect.any(Function),
+      });
+      expect(sidebar.left[0].component).not.toBe(testTab.component);
     });
 
     it('voiden test : call electron API when registering sidebar tabs', async () => {
@@ -580,7 +586,12 @@ describe('createPlugin', () => {
 
       const { panels } = usePluginStore.getState();
       expect(panels.main).toHaveLength(1);
-      expect(panels.main[0]).toEqual(panel);
+      expect(panels.main[0]).toMatchObject({
+        id: panel.id,
+        title: panel.title,
+        component: expect.any(Function),
+      });
+      expect(panels.main[0].component).not.toBe(panel.component);
     });
   });
 

--- a/apps/ui/src/core/editors/voiden/nodes/CustomTableRow.tsx
+++ b/apps/ui/src/core/editors/voiden/nodes/CustomTableRow.tsx
@@ -102,6 +102,9 @@ export const CustomTableRow = TableRow.extend({
       disabled: {
         default: false,
       },
+      omitIfUnresolved: {
+        default: false,
+      },
     };
   },
   renderHTML({ node, HTMLAttributes }) {
@@ -210,9 +213,100 @@ export const CustomTableRow = TableRow.extend({
             const checkStrokeColor = pickContrastingStrokeColor(accentColor);
 
             state.doc.nodesBetween(0, state.doc.content.size, (node, pos) => {
+              if (node.type.name === "table") {
+                const $table = state.doc.resolve(pos + 1);
+                const wrapperName = Array.from(
+                  { length: $table.depth + 1 },
+                  (_, index) => $table.node(index).type.name,
+                ).find((name) =>
+                  [
+                    "headers-table",
+                    "query-table",
+                    "cookies-table",
+                    "multipart-table",
+                    "url-table",
+                    "path-table",
+                    "options-table",
+                  ].includes(name),
+                );
+
+                if (wrapperName) {
+                  const supportsRequired = [
+                    "headers-table",
+                    "query-table",
+                    "cookies-table",
+                    "multipart-table",
+                    "url-table",
+                  ].includes(wrapperName);
+                  const hasDescription = wrapperName !== "cookies-table" && (node.firstChild?.childCount ?? 0) >= 3;
+                  const headerWidget = Decoration.widget(
+                    pos + 1,
+                    () => {
+                      const tr = document.createElement("tr");
+                      tr.setAttribute("contenteditable", "false");
+                      tr.setAttribute("data-request-table-labels", "true");
+
+                      const addHeader = (label: string, width?: number) => {
+                        const th = document.createElement("th");
+                        th.textContent = label;
+                        th.scope = "col";
+                        th.style.cssText = [
+                          width ? `width:${width}px;min-width:${width}px;max-width:${width}px` : "",
+                          "height:30px",
+                          "padding:7px 12px",
+                          "text-align:left",
+                          "vertical-align:middle",
+                          "font-size:10px",
+                          "font-weight:500",
+                          "line-height:1",
+                          "letter-spacing:0.025em",
+                          "text-transform:uppercase",
+                          "color:var(--fg-secondary,var(--editor-fg))",
+                          "border-bottom:1px solid var(--ui-line)",
+                          "border-right:1px solid var(--ui-line)",
+                          "background:transparent",
+                        ].filter(Boolean).join(";");
+                        tr.appendChild(th);
+                        return th;
+                      };
+
+                      const enabledHeader = addHeader("", 28);
+                      enabledHeader.style.padding = "0";
+                      enabledHeader.setAttribute("aria-label", "Enabled");
+
+                      if (supportsRequired) {
+                        const requiredHeader = addHeader("Required", 96);
+                        requiredHeader.style.padding = "7px 10px";
+                        requiredHeader.style.whiteSpace = "nowrap";
+                        requiredHeader.title = "When selected, fail the request if one of this row's variables cannot be resolved";
+                      }
+
+                      addHeader("Key");
+                      const valueHeader = addHeader("Value");
+                      if (hasDescription) {
+                        const descriptionHeader = addHeader("Description");
+                        descriptionHeader.style.borderRight = "none";
+                      } else {
+                        valueHeader.style.borderRight = "none";
+                      }
+
+                      return tr;
+                    },
+                    { side: -10 },
+                  );
+
+                  decorations.push(headerWidget);
+                }
+              }
+
               if (node.type.name !== "tableRow") return;
 
               const disabled = !!node.attrs.disabled;
+              const $row = state.doc.resolve(pos + 1);
+              const supportsOptionalRows = Array.from({ length: $row.depth + 1 }, (_, index) => $row.node(index).type.name)
+                .some((name) =>
+                  ["headers-table", "query-table", "cookies-table", "multipart-table", "url-table"].includes(name),
+                );
 
               const widget = Decoration.widget(
                 pos + 1,
@@ -269,10 +363,88 @@ export const CustomTableRow = TableRow.extend({
 
                   return td;
                 },
-                { side: -1 },
+                { side: -2 },
               );
 
               decorations.push(widget);
+
+              if (supportsOptionalRows) {
+                const required = node.attrs.omitIfUnresolved !== true;
+                const optionalWidget = Decoration.widget(
+                  pos + 1,
+                  (view, getPos) => {
+                    const td = document.createElement("td");
+                    td.setAttribute("contenteditable", "false");
+                    td.setAttribute("data-row-required", String(required));
+                    td.setAttribute("role", "checkbox");
+                    td.setAttribute("aria-checked", String(required));
+                    td.setAttribute("aria-label", "Require all variables in this row to resolve");
+                    td.tabIndex = 0;
+                    td.style.cssText =
+                      "width:96px;min-width:96px;max-width:96px;padding:0;text-align:center;user-select:none;cursor:pointer;vertical-align:middle;border-right:1px solid var(--ui-line,#3a3a3a);";
+
+                    const box = document.createElement("div");
+                    box.style.cssText =
+                      "width:13px;height:13px;border-radius:3px;margin:2px auto;display:flex;align-items:center;justify-content:center;border:1.5px solid;transition:opacity 0.1s;";
+
+                    if (required) {
+                      box.style.borderColor = accentColor;
+                      box.style.backgroundColor = accentColor;
+                      box.innerHTML =
+                        `<svg viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg" style="width:8px;height:8px;display:block"><path d="M1 4L3.5 6.5L9 1" stroke="${checkStrokeColor}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+                    } else {
+                      box.style.borderColor = "var(--ui-line,#555)";
+                      box.style.backgroundColor = "transparent";
+                    }
+
+                    td.title = required
+                      ? "Required: fail the request if a variable is unresolved"
+                      : "Optional: omit this row if a variable is unresolved";
+                    td.appendChild(box);
+
+                    const toggleRequired = () => {
+                      const { state: s, dispatch } = view;
+                      if (!dispatch) return;
+
+                      const widgetPos = getPos();
+                      if (widgetPos == null) return;
+
+                      const $pos = s.doc.resolve(widgetPos);
+                      for (let d = $pos.depth; d >= 0; d--) {
+                        if ($pos.node(d).type.name === "tableRow") {
+                          const rowPos = $pos.before(d);
+                          const rowNode = $pos.node(d);
+                          dispatch(
+                            s.tr.setNodeMarkup(rowPos, null, {
+                              ...rowNode.attrs,
+                              omitIfUnresolved: !rowNode.attrs.omitIfUnresolved,
+                            }),
+                          );
+                          return;
+                        }
+                      }
+                    };
+
+                    td.addEventListener("mousedown", (e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleRequired();
+                    });
+
+                    td.addEventListener("keydown", (e) => {
+                      if (e.key !== "Enter" && e.key !== " ") return;
+                      e.preventDefault();
+                      e.stopPropagation();
+                      toggleRequired();
+                    });
+
+                    return td;
+                  },
+                  { side: -1 },
+                );
+
+                decorations.push(optionalWidget);
+              }
               return false;
             });
 

--- a/apps/ui/src/core/editors/voiden/nodes/__test__/CustomTableRow.layout.test.ts
+++ b/apps/ui/src/core/editors/voiden/nodes/__test__/CustomTableRow.layout.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor, Node } from "@tiptap/core";
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import TableCell from "@tiptap/extension-table-cell";
+import TableHeader from "@tiptap/extension-table-header";
+
+import { CustomTable } from "@/core/editors/voiden/nodes/CustomTable";
+import { CustomTableRow } from "@/core/editors/voiden/nodes/CustomTableRow";
+
+const HeadersTable = Node.create({
+  name: "headers-table",
+  group: "block",
+  content: "table",
+  parseHTML: () => [{ tag: "headers-table" }],
+  renderHTML: () => ["headers-table", 0],
+});
+
+describe("request table column labels", () => {
+  let editor: Editor | undefined;
+
+  afterEach(() => editor?.destroy());
+
+  it("voiden test : renders labels and fields in the same table", () => {
+    editor = new Editor({
+      extensions: [Document, Paragraph, Text, HeadersTable, CustomTable, CustomTableRow, TableCell, TableHeader],
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "headers-table",
+            content: [
+              {
+                type: "table",
+                content: [
+                  {
+                    type: "tableRow",
+                    content: [
+                      { type: "tableCell", content: [{ type: "paragraph", content: [{ type: "text", text: "X-Test" }] }] },
+                      { type: "tableCell", content: [{ type: "paragraph", content: [{ type: "text", text: "value" }] }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const table = editor.view.dom.querySelector("table");
+    const labels = table?.querySelector("tr[data-request-table-labels]");
+    const dataRow = table?.querySelector("tr:not([data-request-table-labels])");
+
+    expect(editor.view.dom.querySelectorAll("tr[data-request-table-labels]")).toHaveLength(1);
+    expect(labels?.parentElement).toBe(dataRow?.parentElement);
+    expect(Array.from(labels?.children ?? []).map((cell) => cell.textContent)).toEqual(["", "Required", "Key", "Value"]);
+    expect(dataRow?.children).toHaveLength(4);
+    expect((labels?.children[1] as HTMLElement).style.width).toBe("96px");
+    expect((labels?.children[1] as HTMLElement).style.whiteSpace).toBe("nowrap");
+    expect((dataRow?.children[1] as HTMLElement).style.width).toBe("96px");
+  });
+});

--- a/apps/ui/src/core/request-engine/__test__/executeSecureRequest.validation.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/executeSecureRequest.validation.test.ts
@@ -126,4 +126,77 @@ describe("executeSecureRequest unresolved variable validation", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it("voiden test : omits optional unresolved header, query, and cookie rows", async () => {
+    await executeSecureRequest(
+      {
+        method: "GET",
+        url: "https://api.example.com/items",
+        headers: [
+          { key: "X-Optional", value: "{{MISSING_HEADER}}", enabled: true, omitIfUnresolved: true },
+          { key: "X-Kept", value: "yes", enabled: true },
+        ],
+        cookies: [
+          { key: "missing", value: "{{MISSING_COOKIE}}", enabled: true, omitIfUnresolved: true },
+          { key: "session", value: "present", enabled: true },
+        ],
+        queryParams: [
+          { key: "optional", value: "{{MISSING_QUERY}}", enabled: true, omitIfUnresolved: true },
+          { key: "kept", value: "yes", enabled: true },
+        ],
+        pathParams: [],
+      },
+      createEnvAdapter(),
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://api.example.com/items?kept=yes");
+    expect(mockFetch.mock.calls[0][1].headers).toMatchObject({
+      "X-Kept": "yes",
+      Cookie: "session=present",
+    });
+    expect(mockFetch.mock.calls[0][1].headers).not.toHaveProperty("X-Optional");
+  });
+
+  it("voiden test : omits an optional unresolved form field", async () => {
+    await executeSecureRequest(
+      {
+        method: "POST",
+        url: "https://api.example.com/items",
+        headers: [],
+        queryParams: [],
+        pathParams: [],
+        contentType: "application/x-www-form-urlencoded",
+        bodyParams: [
+          { key: "optional", value: "{{MISSING_FORM_VALUE}}", type: "text", enabled: true, omitIfUnresolved: true },
+          { key: "kept", value: "yes", type: "text", enabled: true },
+        ],
+      },
+      createEnvAdapter(),
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][1].body).toBe("kept=yes");
+  });
+
+  it("voiden test : still blocks an unresolved form field that is required", async () => {
+    await expect(
+      executeSecureRequest(
+        {
+          method: "POST",
+          url: "https://api.example.com/items",
+          headers: [],
+          queryParams: [],
+          pathParams: [],
+          contentType: "application/x-www-form-urlencoded",
+          bodyParams: [
+            { key: "required", value: "{{MISSING_FORM_VALUE}}", type: "text", enabled: true },
+          ],
+        },
+        createEnvAdapter(),
+      ),
+    ).rejects.toBeInstanceOf(UnresolvedVariablesError);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/apps/ui/src/core/request-engine/__test__/sendRequestHybrid.validation.test.ts
+++ b/apps/ui/src/core/request-engine/__test__/sendRequestHybrid.validation.test.ts
@@ -101,4 +101,38 @@ describe("sendRequestHybrid unresolved variable handling", () => {
       ),
     ).rejects.toBeInstanceOf(UnresolvedVariablesError);
   });
+
+  it("voiden test : preserves required-row metadata for the secure executor", async () => {
+    await sendRequestHybrid(
+      restRequest({
+        url: "https://api.example.com/items",
+        headers: [
+          { key: "X-Optional", value: "{{MISSING_HEADER}}", enabled: true, omitIfUnresolved: true },
+        ],
+        cookies: [
+          { key: "session", value: "{{MISSING_COOKIE}}", enabled: true, omitIfUnresolved: true },
+        ],
+        params: [
+          { key: "filter", value: "{{MISSING_QUERY}}", enabled: true, omitIfUnresolved: true },
+        ],
+        content_type: "application/x-www-form-urlencoded",
+        body_params: [
+          { key: "form", value: "{{MISSING_FORM}}", type: "text", enabled: true, omitIfUnresolved: true },
+        ],
+      }),
+      createMockEditor(),
+      undefined,
+      mockElectron,
+    );
+
+    expect(sendSecure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: [expect.objectContaining({ key: "X-Optional", omitIfUnresolved: true })],
+        cookies: [expect.objectContaining({ key: "session", omitIfUnresolved: true })],
+        queryParams: [expect.objectContaining({ key: "filter", omitIfUnresolved: true })],
+        bodyParams: [expect.objectContaining({ key: "form", omitIfUnresolved: true })],
+      }),
+      undefined,
+    );
+  });
 });

--- a/apps/ui/src/core/request-engine/getRequestFromJson.ts
+++ b/apps/ui/src/core/request-engine/getRequestFromJson.ts
@@ -84,6 +84,7 @@ export const getTable = (
     key: string;
     value: string;
     enabled: boolean;
+    omitIfUnresolved: boolean;
     importedFrom?: string;
     type?: "text" | "file";
   };
@@ -95,7 +96,7 @@ export const getTable = (
         if (node.type === "table") {
           node.content?.forEach((rowNode) => {
             if (rowNode.type === "tableRow") {
-              const kv: KeyValueType = { key: "", value: "", enabled: true, type: "text" };
+              const kv: KeyValueType = { key: "", value: "", enabled: true, omitIfUnresolved: false, type: "text" };
               rowNode.content?.forEach((cellNode, cellIndex) => {
                 if (cellNode.type === "tableCell") {
                   const text = ((cellNode.content && cellNode.content[0].content && cellNode.content[0].content[0]?.text) || "").trim();
@@ -107,7 +108,12 @@ export const getTable = (
                 }
               });
               if (kv.key && kv.value) {
-                allKeyValues.push({ ...kv, enabled: !rowNode.attrs?.disabled, importedFrom: rootNode.attrs?.importedFrom });
+                allKeyValues.push({
+                  ...kv,
+                  enabled: !rowNode.attrs?.disabled,
+                  omitIfUnresolved: rowNode.attrs?.omitIfUnresolved === true,
+                  importedFrom: rootNode.attrs?.importedFrom,
+                });
               }
             }
           });
@@ -239,7 +245,7 @@ export const buildHeadersWithCookies = (editor: Doc, environment?: Record<string
     const cookieString = cookies.map((c) => `${c.key}=${c.value}`).join("; ");
     const idx = headers.findIndex((h) => h.key.toLowerCase() === "cookie");
     if (idx !== -1) headers[idx] = { ...headers[idx], value: headers[idx].value + "; " + cookieString };
-    else headers.push({ key: "Cookie", value: cookieString, enabled: true });
+    else headers.push({ key: "Cookie", value: cookieString, enabled: true, omitIfUnresolved: false });
   }
   return headers;
 };

--- a/apps/ui/src/core/request-engine/pipeline/__test__/pipeline.test.ts
+++ b/apps/ui/src/core/request-engine/pipeline/__test__/pipeline.test.ts
@@ -282,7 +282,7 @@ describe('PipelineExecutor', () => {
       statusText: 'OK',
       headers: new Map([['content-type', 'application/json']]),
       json: async () => ({ success: true }),
-      text: async () => 'success',
+      text: async () => JSON.stringify({ success: true }),
       arrayBuffer: async () => new ArrayBuffer(0),
       url: 'https://api.example.com',
     });
@@ -492,7 +492,7 @@ describe('PipelineExecutor', () => {
 
       await executor.execute();
 
-      expect(responseBody).toEqual({ success: true });
+      expect(responseBody).toBe('{\n  "success": true\n}');
     });
 
     it('voiden test : handle null or undefined response gracefully', async () => {

--- a/apps/ui/src/core/request-engine/pipeline/types.ts
+++ b/apps/ui/src/core/request-engine/pipeline/types.ts
@@ -85,6 +85,14 @@ export interface RestApiRequestState {
     key: string;
     value: string;
     enabled?: boolean;
+    omitIfUnresolved?: boolean;
+  }>;
+
+  cookies?: Array<{
+    key: string;
+    value: string;
+    enabled?: boolean;
+    omitIfUnresolved?: boolean;
   }>;
 
   // Query parameters
@@ -92,6 +100,7 @@ export interface RestApiRequestState {
     key: string;
     value: string;
     enabled?: boolean;
+    omitIfUnresolved?: boolean;
   }>;
 
   // Path parameters (for URL templates like /users/{id})
@@ -111,8 +120,9 @@ export interface RestApiRequestState {
     value: string | File;
     type?: string;
     enabled?: boolean;
+    omitIfUnresolved?: boolean;
   }>;
-  binary?: File | string; // File object or file path string
+  binary?: File | string | string[]; // File object, file path string, or multiple file paths
 
   // Auth profile reference (not the actual credentials)
   authProfile?: string;

--- a/apps/ui/src/core/request-engine/runtimeVariables.ts
+++ b/apps/ui/src/core/request-engine/runtimeVariables.ts
@@ -415,7 +415,18 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
         if (requestState.headers) {
             requestState.headers = requestState.headers.map((header: any) => ({
                 ...header,
+                key: header.key ? replaceProcessVariables(header.key, processVariables) : header.key,
                 value: replaceProcessVariables(header.value, processVariables),
+            }));
+        }
+
+        // Replace in cookies. Cookies stay as individual rows until the secure
+        // executor so optional rows can be omitted independently.
+        if (requestState.cookies) {
+            requestState.cookies = requestState.cookies.map((cookie: any) => ({
+                ...cookie,
+                key: cookie.key ? replaceProcessVariables(cookie.key, processVariables) : cookie.key,
+                value: cookie.value ? replaceProcessVariables(cookie.value, processVariables) : cookie.value,
             }));
         }
 
@@ -423,6 +434,7 @@ export async function preSendProcessHook(requestState: any): Promise<any> {
         if (requestState.queryParams) {
             requestState.queryParams = requestState.queryParams.map((param: any) => ({
                 ...param,
+                key: param.key ? replaceProcessVariables(param.key, processVariables) : param.key,
                 value: param.value ? replaceProcessVariables(param.value, processVariables) : param.value,
             }));
         }

--- a/apps/ui/src/core/request-engine/sendRequestHybrid.ts
+++ b/apps/ui/src/core/request-engine/sendRequestHybrid.ts
@@ -38,7 +38,14 @@ function parseNumberSafe(value: string): number | LosslessNumber {
 /**
  * Get headers with auth merged
  */
-async function getHeaders(headers: any[], auth?: any): Promise<Record<string, string>> {
+type RequestFieldRow = {
+  key: string;
+  value: string;
+  enabled?: boolean;
+  omitIfUnresolved?: boolean;
+};
+
+async function getHeaders(headers: any[], auth?: any): Promise<RequestFieldRow[]> {
   const authHeaders: Record<string, string> = {};
 
   if (auth && auth.enabled && auth.config) {
@@ -91,7 +98,7 @@ async function getHeaders(headers: any[], auth?: any): Promise<Record<string, st
         parts.push('oauth_signature_method="PLAINTEXT"');
         let signature = `${auth.config.consumerSecret || ""}&${auth.config.tokenSecret || ""}`;
         try {
-          signature = await window.electron?.env?.replaceVariables(signature);
+          signature = (await window.electron?.env?.replaceVariables(signature)) ?? signature;
         } catch (e) { console.warn("[auth] Failed to resolve env variables in oauth1 signature:", e); }
           try {
           signature = await replaceProcessVariablesInText(signature);
@@ -117,9 +124,15 @@ async function getHeaders(headers: any[], auth?: any): Promise<Record<string, st
     }
   }
 
-  const finalHeaders: Record<string, string> = headers
+  const finalHeaders: RequestFieldRow[] = Object.entries(authHeaders).map(([key, value]) => ({
+    key,
+    value,
+    enabled: true,
+  }));
+
+  headers
     .filter((header) => header.enabled)
-    .reduce((acc: Record<string, string>, header) => {
+    .forEach((header) => {
       const key = header.key;
       const value = header.value;
 
@@ -128,51 +141,23 @@ async function getHeaders(headers: any[], auth?: any): Promise<Record<string, st
       // must come from the actual FormData we build, or the server can't
       // find the real part delimiter and multipart parsing breaks.
       if (key.trim().toLowerCase() === "content-type" && value.trim().toLowerCase().startsWith("multipart/form-data")) {
-        return acc;
+        return;
       }
 
       if (key && value) {
-        acc[key] = value;
+        const next = {
+          key,
+          value,
+          enabled: true,
+          omitIfUnresolved: header.omitIfUnresolved === true,
+        };
+        const existingIndex = finalHeaders.findIndex((candidate) => candidate.key === key);
+        if (existingIndex >= 0) finalHeaders[existingIndex] = next;
+        else finalHeaders.push(next);
       }
-
-      return acc;
-    }, authHeaders);
+    });
 
   return finalHeaders;
-}
-
-/**
- * Get query parameters with auth merged
- */
-function getParameters(parameters: any[], auth?: any): string {
-  let authQuery = "";
-  if (auth && auth.config && auth.enabled) {
-    if (auth.type === "api-key" && auth.config.in === "query") {
-      authQuery = `${auth.config.key}=${auth.config.value}`;
-    } else if (auth.type === "oauth2" && auth.config.addTokenTo === "query" && auth.config.accessToken) {
-      authQuery = `access_token=${encodeURIComponent(auth.config.accessToken)}`;
-    }
-  }
-
-  const filteredParameters = parameters.filter((parameter) => parameter.enabled && (parameter.key || parameter.value));
-
-  const queryString = filteredParameters
-    .map((obj) => {
-      const key = obj.key;
-      const value = obj.value;
-      return `${key}=${value}`;
-    })
-    .join("&");
-
-  if (authQuery && queryString) {
-    return `?${authQuery}&${queryString}`;
-  } else if (authQuery) {
-    return `?${authQuery}`;
-  } else if (queryString) {
-    return `?${queryString}`;
-  }
-
-  return "";
 }
 
 /**
@@ -184,15 +169,6 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
   // Merge auth into headers and query params
   const mergedHeaders = await getHeaders(data.headers, data.auth);
 
-  const parameters = getParameters(data.params, data.auth);
-
-  // Convert headers object back to array format
-  const headersArray = Object.entries(mergedHeaders).map(([key, value]) => ({
-    key,
-    value,
-    enabled: true,
-  }));
-
   // Parse query params
   const queryParamsArray = data.params
     .filter((p) => p.enabled)
@@ -200,6 +176,7 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
       key: p.key,
       value: p.value,
       enabled: p.enabled,
+      omitIfUnresolved: p.omitIfUnresolved === true,
     }));
 
   // Add auth query params if present
@@ -209,12 +186,14 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
         key: data.auth.config.key,
         value: data.auth.config.value || '',
         enabled: true,
+        omitIfUnresolved: false,
       });
     } else if (data.auth.type === 'oauth2' && data.auth.config.addTokenTo === 'query' && data.auth.config.accessToken) {
       queryParamsArray.push({
         key: 'access_token',
         value: data.auth.config.accessToken,
         enabled: true,
+        omitIfUnresolved: false,
       });
     }
   }
@@ -229,7 +208,15 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
   const result = {
     method: data.method,
     url: data.url,
-    headers: headersArray,
+    headers: mergedHeaders,
+    cookies: (data.cookies || [])
+      .filter((cookie) => cookie.enabled)
+      .map((cookie) => ({
+        key: cookie.key,
+        value: cookie.value,
+        enabled: true,
+        omitIfUnresolved: cookie.omitIfUnresolved === true,
+      })),
     queryParams: queryParamsArray,
     pathParams: (data.path_params || [])
       .filter((p) => p.enabled)
@@ -240,11 +227,12 @@ async function convertToRestApiRequestState(data: Request): Promise<RestApiReque
       })),
     body: normalizedBody,
     contentType: data.content_type,
-    bodyParams: data.body_params?.map((p) => ({
+    bodyParams: data.body_params?.filter((p) => p.value !== null).map((p) => ({
       key: p.key,
-      value: p.value,
+      value: p.value as string | File,
       type: p.type,
       enabled: p.enabled,
+      omitIfUnresolved: p.omitIfUnresolved === true,
     })),
     binary: data.binary,
     authProfile: undefined, // TODO: Auth profile reference
@@ -322,10 +310,7 @@ export async function sendRequestHybrid(
     } else if (request.protocolType === 'graphql') {
       // Merge auth into headers for GraphQL (same logic as REST via getHeaders)
       const mergedHeaders = await getHeaders(request.headers || [], request.auth);
-      const headersArray = Object.entries(mergedHeaders).map(([key, value]) => ({
-        key, value, enabled: true,
-      }));
-      requestState = { ...request, headers: headersArray };
+      requestState = { ...request, headers: mergedHeaders };
     }
 
     const url = requestState.url.toLowerCase();

--- a/apps/ui/src/core/types/requests.ts
+++ b/apps/ui/src/core/types/requests.ts
@@ -151,6 +151,7 @@ export interface RequestParam {
   key: string;
   value: string;
   type?: "text" | "file";
+  omitIfUnresolved?: boolean;
 }
 export interface BodyParam {
   id?: string; // make it mandatory after refactor
@@ -158,6 +159,7 @@ export interface BodyParam {
   key: string;
   value: string | File | null;
   type?: string;
+  omitIfUnresolved?: boolean;
 }
 
 export interface Request {
@@ -178,6 +180,7 @@ export interface Request {
   postscript: any;
   content_type: ContentType;
   headers: RequestParam[];
+  cookies?: RequestParam[];
   params: RequestParam[];
   path_params: RequestParam[];
   body_params: BodyParam[];
@@ -193,6 +196,7 @@ export interface Request {
   auth: Authorization;
   openApiSpecs?: JsonData;
   preRequestResult?: PreRequestResult;
+  options?: Record<string, string>;
 }
 
 interface DeletedRequest {

--- a/packages/executors/src/pipeline/types.ts
+++ b/packages/executors/src/pipeline/types.ts
@@ -53,12 +53,13 @@ export enum PipelineStage {
 export interface RestApiRequestState {
   method: string
   url: string
-  headers:     Array<{ key: string; value: string; enabled?: boolean }>
-  queryParams: Array<{ key: string; value: string; enabled?: boolean }>
+  headers:     Array<{ key: string; value: string; enabled?: boolean; omitIfUnresolved?: boolean }>
+  cookies?:    Array<{ key: string; value: string; enabled?: boolean; omitIfUnresolved?: boolean }>
+  queryParams: Array<{ key: string; value: string; enabled?: boolean; omitIfUnresolved?: boolean }>
   pathParams:  Array<{ key: string; value: string; enabled?: boolean }>
   body?: string
   contentType?: string
-  bodyParams?: Array<{ key: string; value: string | File; type?: string; enabled?: boolean }>
+  bodyParams?: Array<{ key: string; value: string | File; type?: string; enabled?: boolean; omitIfUnresolved?: boolean }>
   binary?: File | string | string[]
   authProfile?: string
   preRequestResult?: any

--- a/packages/executors/src/secureRequest.ts
+++ b/packages/executors/src/secureRequest.ts
@@ -15,7 +15,11 @@ import mimeTypes from 'mime-types'
 import type { RestApiRequestState } from './pipeline/types.js'
 import { executeWebSocket } from './websocket.js'
 import { executeGrpc } from './grpc.js'
-import { assertNoUnresolvedTemplates } from './unresolvedVariables.js'
+import {
+  assertNoUnresolvedTemplates,
+  UnresolvedVariablesError,
+  validateResolvedStrings,
+} from './unresolvedVariables.js'
 
 // ─── Adapter interface ────────────────────────────────────────────────────────
 
@@ -125,6 +129,31 @@ function validateResolvedOutgoing(
   assertNoUnresolvedTemplates(parts)
 }
 
+type RequestField = {
+  key: string
+  value: string
+  enabled?: boolean
+  omitIfUnresolved?: boolean
+}
+
+async function resolveRequestField(
+  field: RequestField,
+  replaceVar: (text: string) => Promise<string>,
+): Promise<{ key: string; value: string } | null> {
+  if (field.enabled === false) return null
+
+  const key = await replaceVar(String(field.key ?? ''))
+  const value = await replaceVar(String(field.value ?? ''))
+  const validation = validateResolvedStrings([key, value])
+
+  if (!validation.ok) {
+    if (field.omitIfUnresolved === true) return null
+    throw new UnresolvedVariablesError(validation.message, validation.unresolved)
+  }
+
+  return { key, value }
+}
+
 // ─── Main executor ────────────────────────────────────────────────────────────
 
 export async function executeSecureRequest(
@@ -139,19 +168,31 @@ export async function executeSecureRequest(
   // ── 2. Replace variables in headers ──────────────────────────────────────
   const headers: Record<string, string> = {}
   for (const h of requestState.headers ?? []) {
-    if (h.enabled !== false && h.key) {
-      headers[await rv(h.key)] = await rv(h.value)
+    const resolved = await resolveRequestField(h, rv)
+    if (resolved?.key) headers[resolved.key] = resolved.value
+  }
+
+  // Cookies remain separate rows until this point so an optional unresolved
+  // cookie can be omitted without affecting the other Cookie header values.
+  const cookieParts: string[] = []
+  for (const cookie of requestState.cookies ?? []) {
+    const resolved = await resolveRequestField(cookie, rv)
+    if (resolved?.key) cookieParts.push(`${resolved.key}=${resolved.value}`)
+  }
+  if (cookieParts.length > 0) {
+    const existingCookieHeader = Object.keys(headers).find(key => key.toLowerCase() === 'cookie')
+    if (existingCookieHeader) {
+      headers[existingCookieHeader] = [headers[existingCookieHeader], ...cookieParts].filter(Boolean).join('; ')
+    } else {
+      headers.Cookie = cookieParts.join('; ')
     }
   }
 
   // ── 3. Replace variables in query params → append to URL ─────────────────
   const queryParts: string[] = []
   for (const p of requestState.queryParams ?? []) {
-    if (p.enabled !== false) {
-      const k = await rv(p.key)
-      const v = await rv(p.value)
-      if (k) queryParts.push(`${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-    }
+    const resolved = await resolveRequestField(p, rv)
+    if (resolved?.key) queryParts.push(`${encodeURIComponent(resolved.key)}=${encodeURIComponent(resolved.value)}`)
   }
   if (queryParts.length > 0) {
     url += url.includes('?') ? `&${queryParts.join('&')}` : `?${queryParts.join('&')}`
@@ -262,6 +303,7 @@ export async function executeSecureRequest(
   }
 
   // ── 9. Build request body ─────────────────────────────────────────────────
+  const resolvedBodyParamSummaries: Array<{ key: string; value: string; type?: string }> = []
   if (requestState.binary) {
     if (Array.isArray(requestState.binary)) {
       // Multiple binary files → send as multipart/form-data, one entry per file
@@ -290,24 +332,23 @@ export async function executeSecureRequest(
     }
   } else if (requestState.bodyParams?.length) {
     const bodyParams = requestState.bodyParams as any[]
-    const resolvedBodyParamTexts: string[] = []
 
     if (requestState.contentType === 'multipart/form-data') {
       const formData = new FormData()
       for (const p of bodyParams) {
-        if (p.enabled === false) continue
-        if (p.type === 'file' && p.value) {
+        const resolved = await resolveRequestField(p, rv)
+        if (!resolved) continue
+        if (p.type === 'file' && resolved.value) {
           if (!adapter.readFile) throw new Error('Multipart file upload requires adapter.readFile')
-          const filePath = await rv(p.value as string)
-          resolvedBodyParamTexts.push(filePath)
+          const filePath = resolved.value
           const fileBuffer = await adapter.readFile(filePath)
           const fileName = filePath.split('/').pop() ?? 'file'
           const blob = new Blob([fileBuffer], { type: getFileMimeType(filePath) })
-          formData.append(p.key, blob, fileName)
+          formData.append(resolved.key, blob, fileName)
+          resolvedBodyParamSummaries.push({ key: resolved.key, value: filePath, type: 'file' })
         } else if (p.type === 'text') {
-          const resolvedValue = await rv(p.value as string)
-          resolvedBodyParamTexts.push(resolvedValue)
-          formData.append(p.key, resolvedValue)
+          formData.append(resolved.key, resolved.value)
+          resolvedBodyParamSummaries.push({ key: resolved.key, value: resolved.value, type: 'text' })
         }
       }
       fetchOptions.body = formData
@@ -315,17 +356,22 @@ export async function executeSecureRequest(
     } else if (requestState.contentType === 'application/x-www-form-urlencoded') {
       const params = new URLSearchParams()
       for (const p of bodyParams) {
-        if (p.enabled !== false && p.type === 'text') {
-          const resolvedValue = await rv(p.value as string)
-          resolvedBodyParamTexts.push(resolvedValue)
-          params.append(p.key, resolvedValue)
-        }
+        if (p.type !== 'text') continue
+        const resolved = await resolveRequestField(p, rv)
+        if (!resolved) continue
+        params.append(resolved.key, resolved.value)
+        resolvedBodyParamSummaries.push({ key: resolved.key, value: resolved.value, type: 'text' })
       }
       fetchOptions.body = params.toString()
       if (!hasHttpHeader(headers, 'Content-Type')) headers['Content-Type'] = 'application/x-www-form-urlencoded'
     }
 
-    validateResolvedOutgoing(url, headers, body, resolvedBodyParamTexts)
+    validateResolvedOutgoing(
+      url,
+      headers,
+      body,
+      resolvedBodyParamSummaries.flatMap(param => [param.key, param.value]),
+    )
   } else if (requestState.method !== 'GET' && body) {
     fetchOptions.body = body
     if (requestState.contentType && !hasHttpHeader(headers, 'Content-Type')) {
@@ -364,18 +410,16 @@ export async function executeSecureRequest(
     requestBodySent = body
     requestBodyContentType = requestState.contentType ?? headers['Content-Type'] ?? null
   } else if (requestState.bodyParams?.length) {
-    const bodyParams = requestState.bodyParams as any[]
     if (requestState.contentType === 'multipart/form-data') {
-      requestBodySent = bodyParams
-        .filter(p => p.enabled !== false)
+      requestBodySent = resolvedBodyParamSummaries
         .map(p => p.type === 'file'
           ? `${p.key}: [file] ${String(p.value).split('/').pop()}`
           : `${p.key}: ${p.value}`)
         .join('\n')
       requestBodyContentType = 'multipart/form-data'
     } else if (requestState.contentType === 'application/x-www-form-urlencoded') {
-      requestBodySent = bodyParams
-        .filter(p => p.enabled !== false && p.type === 'text')
+      requestBodySent = resolvedBodyParamSummaries
+        .filter(p => p.type === 'text')
         .map(p => `${p.key}=${p.value}`)
         .join('&')
       requestBodyContentType = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
Addresses #508

Alongside [plugin changes](https://github.com/VoidenHQ/plugin-voiden-rest-api/pull/1)

### Changes:

- Adds a **Required** checkbox to request-table rows alongside **Enabled**.
- Omits enabled-but-optional fields when their variables cannot be resolved.
- Preserves validation errors for enabled and required fields with unresolved variables.
- Keeps existing rows required by default for backward compatibility.
- Adds aligned headers for Enabled, Required, Key, Value, and Description.
- Passes required-field metadata through request construction and secure execution.
- Adds tests for validation, omission behavior, hybrid requests, and header alignment.
- Validation: 12 focused tests and the executor TypeScript check passed.