### PR TITLE
fix: preserve terminal output order

### DIFF
--- a/apps/ui/src/core/terminal/__test__/terminalOutputQueue.test.ts
+++ b/apps/ui/src/core/terminal/__test__/terminalOutputQueue.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalOutputQueue } from "../terminalOutputQueue";
+
+const createTerminalHarness = () => {
+  const writes: string[] = [];
+  const callbacks: Array<() => void> = [];
+  const terminal = {
+    write: vi.fn((data: string, callback?: () => void) => {
+      writes.push(data);
+      if (callback) callbacks.push(callback);
+    }),
+  };
+
+  const completeNextWrite = () => {
+    const callback = callbacks.shift();
+    if (!callback) throw new Error("No terminal write is pending");
+    callback();
+  };
+
+  const completeAllWrites = () => {
+    while (callbacks.length > 0) completeNextWrite();
+  };
+
+  return { terminal, writes, completeNextWrite, completeAllWrites };
+};
+
+describe("TerminalOutputQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("batches small writes received during the initial delay", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+
+    queue.enqueue("first");
+    queue.enqueue(" second");
+    vi.advanceTimersByTime(8);
+
+    expect(harness.writes).toEqual(["first second"]);
+  });
+
+  it("keeps later output behind every pending chunk", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+    const firstBatch = "A".repeat(4097);
+    const secondBatch = "B".repeat(2049);
+
+    queue.enqueue(firstBatch);
+    vi.advanceTimersByTime(8);
+    expect(harness.writes).toEqual(["A".repeat(2048)]);
+
+    queue.enqueue(secondBatch);
+    vi.advanceTimersByTime(8);
+    expect(harness.writes).toHaveLength(1);
+
+    harness.completeAllWrites();
+    expect(harness.writes.join("")).toBe(firstBatch + secondBatch);
+    expect(harness.writes.every((chunk) => chunk.length <= 2048)).toBe(true);
+  });
+
+  it("preserves an ANSI sequence split at the chunk boundary", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+    const firstBatch = `${"A".repeat(2047)}\x1b[38;2;153;204;255mTEXT`;
+    const secondBatch = "\x1b[0mB";
+
+    queue.enqueue(firstBatch);
+    vi.advanceTimersByTime(8);
+    queue.enqueue(secondBatch);
+    harness.completeAllWrites();
+
+    expect(harness.writes.join("")).toBe(firstBatch + secondBatch);
+  });
+
+  it("starts a new batch after the previous drain becomes empty", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+
+    queue.enqueue("first");
+    vi.advanceTimersByTime(8);
+    harness.completeNextWrite();
+
+    queue.enqueue("second");
+    expect(harness.writes).toEqual(["first"]);
+    vi.advanceTimersByTime(8);
+
+    expect(harness.writes).toEqual(["first", "second"]);
+  });
+
+  it("drops pending work after disposal", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+
+    queue.enqueue("pending");
+    queue.dispose();
+    vi.runAllTimers();
+
+    expect(harness.writes).toEqual([]);
+  });
+
+  it("does not continue an active drain after disposal", () => {
+    const harness = createTerminalHarness();
+    const queue = new TerminalOutputQueue(() => harness.terminal);
+
+    queue.enqueue("A".repeat(4097));
+    vi.advanceTimersByTime(8);
+    queue.dispose();
+    harness.completeNextWrite();
+
+    expect(harness.writes).toEqual(["A".repeat(2048)]);
+  });
+});

--- a/apps/ui/src/core/terminal/components/Terminal.tsx
+++ b/apps/ui/src/core/terminal/components/Terminal.tsx
@@ -8,6 +8,7 @@ import { useNerdFont } from "../hooks/useNerdFont";
 import { useClosePanelTab, useGetPanelTabs } from "@/core/layout/hooks";
 import { usePanelStore } from "@/core/stores/panelStore";
 import { getShortcutLabel, matchesShortcut } from "@/core/shortcuts";
+import { TerminalOutputQueue } from "../terminalOutputQueue";
 
 interface TerminalProps {
   tabId: string;
@@ -32,9 +33,6 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
   const xtermRef = useRef<XTerm | null>(null);
   // In our design, we use the tabId as the session id.
   const sessionIdRef = useRef<string | null>(null);
-  // Throttling for terminal output
-  const outputBufferRef = useRef<string>("");
-  const writeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Get font size from settings — the terminal is chrome/UI, not document
   // content, so it follows UI font size rather than the editor's, fallback to 13
@@ -55,48 +53,6 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
     if (cols && rows) {
       window.electron?.terminal.resize?.({ id: sessionIdRef.current, cols, rows });
     }
-  };
-
-  // Throttled write function to batch terminal output for better performance
-  const throttledWrite = (data: string) => {
-    outputBufferRef.current += data;
-
-    if (writeTimeoutRef.current) {
-      return; // Already scheduled
-    }
-
-    // Use requestIdleCallback for writing during browser idle time
-    // This prevents blocking the main thread during heavy terminal output
-    writeTimeoutRef.current = setTimeout(() => {
-      if (xtermRef.current && outputBufferRef.current) {
-        const chunk = outputBufferRef.current;
-        outputBufferRef.current = "";
-
-        // For large chunks (>2KB), split writes across idle callbacks
-        if (chunk.length > 2048) {
-          let offset = 0;
-          const writeChunk = () => {
-            if (offset < chunk.length && xtermRef.current) {
-              const slice = chunk.slice(offset, offset + 2048);
-              xtermRef.current.write(slice);
-              offset += 2048;
-              if (offset < chunk.length) {
-                // Use requestIdleCallback if available, otherwise requestAnimationFrame
-                if ('requestIdleCallback' in window) {
-                  (window as any).requestIdleCallback(writeChunk, { timeout: 50 });
-                } else {
-                  requestAnimationFrame(writeChunk);
-                }
-              }
-            }
-          };
-          writeChunk();
-        } else {
-          xtermRef.current.write(chunk);
-        }
-      }
-      writeTimeoutRef.current = null;
-    }, 8); // Reduced batch interval for faster updates
   };
 
   // Debounced fit terminal to prevent excessive calls
@@ -269,8 +225,8 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
     xterm.open(terminalRef.current);
     xterm.focus();
     refreshAfterFontLoad(xterm, effectiveFontFamily, fontSize);
+    const outputQueue = new TerminalOutputQueue(() => xtermRef.current);
 
-   
     const pasteEventHandler = (e: ClipboardEvent) => {
       e.preventDefault();
       e.stopPropagation();
@@ -407,7 +363,7 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
 
       // Subscribe to output for this session and capture the cleanup function.
       const unsubscribeOutput = window.electron?.terminal.onOutput(id, (data: string) => {
-        throttledWrite(data);
+        outputQueue.enqueue(data);
       });
       if (unsubscribeOutput) {
         cleanupFunctionsRef.current.push(unsubscribeOutput);
@@ -435,11 +391,7 @@ export const Terminal = ({ tabId, cwd }: TerminalProps) => {
       mounted = false;
 
       // Clear pending operations
-      if (writeTimeoutRef.current) {
-        clearTimeout(writeTimeoutRef.current);
-        writeTimeoutRef.current = null;
-      }
-      outputBufferRef.current = "";
+      outputQueue.dispose();
 
       if (debouncedFitRef.current) {
         clearTimeout(debouncedFitRef.current);

--- a/apps/ui/src/core/terminal/terminalOutputQueue.ts
+++ b/apps/ui/src/core/terminal/terminalOutputQueue.ts
@@ -1,0 +1,67 @@
+const WRITE_BATCH_DELAY_MS = 8;
+const MAX_WRITE_CHUNK_LENGTH = 2048;
+
+interface TerminalWriter {
+  write(data: string, callback: () => void): void;
+}
+
+/** Serializes renderer writes so PTY output reaches xterm in order. */
+export class TerminalOutputQueue {
+  private buffer = "";
+  private writeTimeout: ReturnType<typeof setTimeout> | null = null;
+  private isWriting = false;
+  private disposed = false;
+
+  constructor(private readonly getTerminal: () => TerminalWriter | null) {}
+
+  /** Adds terminal output to the shared FIFO buffer. */
+  enqueue(data: string): void {
+    if (this.disposed || !data) return;
+
+    this.buffer += data;
+    if (this.writeTimeout !== null || this.isWriting) return;
+
+    this.writeTimeout = setTimeout(() => {
+      this.writeTimeout = null;
+      this.isWriting = true;
+      this.writeNextChunk();
+    }, WRITE_BATCH_DELAY_MS);
+  }
+
+  /** Cancels queued output and prevents pending callbacks from continuing. */
+  dispose(): void {
+    this.disposed = true;
+    this.buffer = "";
+    this.isWriting = false;
+
+    if (this.writeTimeout !== null) {
+      clearTimeout(this.writeTimeout);
+      this.writeTimeout = null;
+    }
+  }
+
+  private writeNextChunk = (): void => {
+    if (this.disposed) {
+      this.isWriting = false;
+      return;
+    }
+
+    const terminal = this.getTerminal();
+    if (!terminal) {
+      this.buffer = "";
+      this.isWriting = false;
+      return;
+    }
+
+    const chunk = this.buffer.slice(0, MAX_WRITE_CHUNK_LENGTH);
+    if (!chunk) {
+      this.isWriting = false;
+      return;
+    }
+
+    this.buffer = this.buffer.slice(chunk.length);
+    // Do not take another slice until xterm has parsed this one. This keeps
+    // later PTY events behind every byte that was already queued.
+    terminal.write(chunk, this.writeNextChunk);
+  };
+}


### PR DESCRIPTION
## Summary

- Serialize terminal output through a single FIFO queue instead of starting overlapping write chains.
- Wait for xterm to finish parsing each 2 KB slice before writing the next one.
- Cancel queued output safely when the terminal unmounts.
- Add deterministic regression coverage for burst ordering, ANSI boundaries, drain restart, and disposal.

## Root cause

The renderer cleared its write timer after starting only the first slice of a large batch. If another PTY event arrived while the remaining slices were still pending, a second chain could overtake them (`A1, B1, A2` instead of `A1, A2, B1`).

When this happened across an ANSI sequence, escape parameters could be rendered as text and corrupt the terminal input line.

## Testing

- `yarn workspace voiden-ui test --run src/core/terminal/__test__/terminalOutputQueue.test.ts` — 6 passed
- `yarn test:ui --run` — 17/19 files and 200/201 tests passed
  - Existing `plugincontext` mock failure: missing `previewProseClasses`
  - Existing pipeline assertion failure: receives `"success"` instead of `{ success: true }`
- Targeted strict TypeScript check — passed
- Changed-file ESLint and Prettier — passed
- `git diff --check` — passed

Fixes #551