### PR TITLE
fix(winget): pin InstallerUrl to the version-pinned artifact, not "latest"

### DIFF
--- a/apps/electron/publish-winget.js
+++ b/apps/electron/publish-winget.js
@@ -48,7 +48,18 @@ const MANIFEST_PATH = `manifests/v/Voiden/${PACKAGE_NAME_PART}/${version}`;
 const UPSTREAM_OWNER = 'microsoft';
 const UPSTREAM_REPO = 'winget-pkgs';
 const MANIFEST_SCHEMA_VERSION = '1.12.0';
-const INSTALLER_URL = `https://voiden.md/api/download/${channel}/win32/x64/setup-latest.exe`;
+// Must be a version-pinned URL, not the "latest" pointer — winget-pkgs keeps
+// every version's manifest forever with InstallerSha256 baked in at publish
+// time, so a URL a future release overwrites breaks that manifest's hash
+// check as soon as the next version ships (this is what was happening:
+// setup-latest.exe is a mutable "latest" pointer, so every previously
+// published manifest's hash went stale the moment a newer version replaced
+// it). The NSIS installer itself is already published under a real,
+// immutable, version-pinned filename by the "Publish to S3 — Windows" step
+// (electron-forge's publisher-s3, from forge.config.ts) — reference that
+// directly instead of a separate "latest" copy.
+const INSTALLER_FILENAME = `${packageJson.productName || 'Voiden'} Setup ${version}.exe`;
+const INSTALLER_URL = `https://voiden.md/api/download/${channel}/win32/x64/${encodeURIComponent(INSTALLER_FILENAME)}`;
 const GITHUB_API = 'https://api.github.com';
 
 console.log(`\n📦 Winget Publisher — Voiden v${version} [${channel}]\n`);


### PR DESCRIPTION
## Problem
\`publish-winget.js\` hashed \`setup-latest.exe\` — a URL whose contents change on every new release — for the winget manifest's `InstallerSha256`. winget-pkgs keeps every published version's manifest forever with that hash baked in, so once a newer release overwrote `setup-latest.exe`, every already-merged manifest's hash went stale.

This is live right now: `setup-latest.exe` currently serves 2.3.0-beta.2's installer, but the merged `Voiden.Voiden-Beta` 2.3.0-beta.1 manifest still has 2.3.0-beta.1's hash → `winget install Voiden.Voiden-Beta` fails with a hash mismatch for anyone on that version.

## Fix
Point `InstallerUrl` at the installer's real, immutable, version-pinned filename (`Voiden Setup <version>.exe`) — already published by the existing "Publish to S3 — Windows" step (electron-forge's `publisher-s3`) — instead of the mutable "latest" pointer.

## Follow-up needed
This only fixes future manifest publishes. The already-merged `2.3.0-beta.1` manifest in `microsoft/winget-pkgs` is still broken, and `2.3.0-beta.2` was never published there at all — I'll open a manifest PR against `microsoft/winget-pkgs` for `2.3.0-beta.2` using the corrected script once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)