### PR TITLE
feat(table-suggestions): pass tabId into registered suggestion functions

### DIFF
--- a/apps/ui/src/core/editors/voiden/extensions/TableCellAutocomplete.tsx
+++ b/apps/ui/src/core/editors/voiden/extensions/TableCellAutocomplete.tsx
@@ -165,8 +165,14 @@ export const TableCellAutocomplete = Extension.create({
           // Look up suggestions from the plugin registry — row's other cells
           // (e.g. the header key already typed in column 0) let a plugin
           // tailor a column's suggestions instead of a fixed static list.
+          // tabId (set on the editor at mount, see VoidenEditor.tsx) lets a
+          // plugin go further and pull suggestions from live app state, e.g.
+          // the current tab's last response (see assertions-table).
           const rowContext = getRowCellsText(editor.state);
-          const items = getTableSuggestions(tableType, columnIndex, rowContext);
+          const items = getTableSuggestions(tableType, columnIndex, {
+            rowContext,
+            tabId: editor.storage?.tabId,
+          });
           if (!items.length) return [];
 
           if (!query) return items;
@@ -273,7 +279,10 @@ export const TableCellAutocomplete = Extension.create({
         if (columnIndex < 0) return false;
 
         const rowContext = getRowCellsText(state);
-        const items = getTableSuggestions(tableType, columnIndex, rowContext);
+        const items = getTableSuggestions(tableType, columnIndex, {
+          rowContext,
+          tabId: editor.storage?.tabId,
+        });
         if (!items.length) return false;
 
         openManualSuggestionPopup(editor, items);

--- a/apps/ui/src/plugins.tsx
+++ b/apps/ui/src/plugins.tsx
@@ -489,13 +489,21 @@ const linkableNodeTypes = new Set<string>(coreLinkableNodeTypes);
 const nodeDisplayNames = new Map<string, string>(Object.entries(coreNodeDisplayNames));
 
 // Global registry for table cell autocomplete suggestions (plugin-owned).
-// A column's suggestions can be a static list, or a function of the other
-// cells already filled in on that row (e.g. headers-table's value column
-// tailoring its list to whichever header key was typed in column 0).
+// A column's suggestions can be a static list, or a function of the row/tab
+// context — e.g. headers-table's value column tailoring its list to whichever
+// header key was typed in column 0 (rowContext), or assertions-table's field
+// column offering paths pulled from the current tab's last response (tabId,
+// added for issue #548 — see plugins/simple-assertions).
 export type TableSuggestionItem = { label: string; description?: string };
+export interface TableSuggestionContext {
+  /** Other cells already filled in on this row, keyed by column index. */
+  rowContext: Record<number, string>;
+  /** tabId of the editor the table lives in (editor.storage.tabId), if known. */
+  tabId?: string;
+}
 export type TableSuggestionsForColumn =
   | TableSuggestionItem[]
-  | ((rowContext: Record<number, string>) => TableSuggestionItem[]);
+  | ((context: TableSuggestionContext) => TableSuggestionItem[]);
 const tableSuggestionsRegistry = new Map<string, { [columnIndex: number]: TableSuggestionsForColumn }>();
 
 // Global registry for block outline metadata (label + lucide icon name) — registered by plugins
@@ -717,13 +725,13 @@ export const getNodeDisplayName = (nodeType: string): string | undefined => {
 export const getTableSuggestions = (
   tableType: string,
   columnIndex: number,
-  rowContext: Record<number, string> = {},
+  context: TableSuggestionContext = { rowContext: {} },
 ): Array<{ label: string; description?: string }> => {
   const config = tableSuggestionsRegistry.get(tableType);
   if (!config) return [];
   const forColumn = config[columnIndex];
   if (!forColumn) return [];
-  return typeof forColumn === 'function' ? forColumn(rowContext) : forColumn;
+  return typeof forColumn === 'function' ? forColumn(context) : forColumn;
 };
 
 export class PluginPermissionError extends Error {


### PR DESCRIPTION
## Description
Threads `tabId` into a registered table-cell suggestion function's arguments (`{ rowContext, tabId }` instead of just `rowContext`), so a per-column suggestion function can look up the active tab's response (e.g. via `useResponseStore`) instead of only having the current row's own cell values to work with.

Backward compatible — no other registration used the function form yet (headers-table/options-table are still static arrays).

This unblocks `plugin-simple-assertions`' response-derived Field-column autocomplete (issue #548), which is already merged and pushed on `main` there but was silently returning no suggestions without this — `TableCellAutocomplete.tsx` wasn't passing `tabId` through at all, so `getResponseFieldSuggestions(tabId)` always received `undefined`.

## Files
- `apps/ui/src/plugins.tsx` — `TableSuggestionsForColumn`'s function form now takes `{ rowContext, tabId }`; `getTableSuggestions()` updated to match.
- `apps/ui/src/core/editors/voiden/extensions/TableCellAutocomplete.tsx` — both call sites now pass `tabId: editor.storage?.tabId`.

## Testing
- `tsc --noEmit`: same 385 pre-existing errors with or without this change — zero new ones.
- No app-release action needed for this alone — plugins update independently; this only needs to ride along in whatever the next app build happens to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)