### PR TITLE
ci: register release-mcp.yml on main

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,0 +1,158 @@
+# Builds and publishes @voiden/mcp to npm, and attaches a .tgz to a GitHub Release.
+#
+# Trigger: manual (workflow_dispatch)
+# Bump the version in packages/voiden-mcp/package.json, commit, then trigger this workflow.
+#
+# @voiden/mcp is the package that actually runs the MCP server (discover →
+# verify → serve, health checks, graceful shutdown, --tunnel, --scheduler).
+# Standalone — nothing wraps or depends on it at publish time. The `voiden`
+# CLI's `agent` command (apps/electron) registers a project's .mcp.json to
+# launch this package at runtime, but that's a source-level dependency only
+# (npx @voiden/mcp <path>, resolved at install time on the end user's
+# machine), not a build/publish-time one — this workflow doesn't need to
+# coordinate with anything else the way release-runner.yml's own executors
+# dependency does.
+#
+# @voiden/mcp depends on @voiden/runner (workspace) — its "main"/"exports"
+# point at @voiden/runner's compiled dist/lib.js, so @voiden/runner has to be
+# built first (same way release-runner.yml itself does) before this
+# package's own build/publish can succeed.
+#
+# The source dependency is "@voiden/runner": "workspace:*", which is only
+# meaningful to Yarn. A plain `npm publish` (not `yarn npm publish`) applies
+# npm's own workspace-protocol rewrite instead, which turns "workspace:*"
+# into a bare "*" — not the exact built version — so a fresh
+# `npm install @voiden/mcp` can silently resolve @voiden/runner to
+# whatever's tagged "latest" on npm, not the version this was built/tested
+# against. This workflow verifies that version is actually published (release
+# runner separately via release-runner.yml if not) and pins the exact version
+# before publishing.
+#
+# Publishes via npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed.
+# One-time setup required on npmjs.com: package Settings → Trusted Publisher →
+# add GitHub Actions with org "VoidenHQ", repo "voiden", workflow "release-mcp.yml".
+
+name: Release voiden-mcp
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Build, Publish & Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read server version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./packages/voiden-mcp/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=mcp-v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node (with npm registry auth)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Enable Corepack (Yarn)
+        run: corepack enable
+
+      # Same prep the runner/app releases use — clones plugin-registry + core
+      # plugins into plugins/, then yarn installs workspace deps. Needed so
+      # @voiden/runner's own build (next step) succeeds the same way it does
+      # in release-runner.yml.
+      - name: Run cleanup (clone plugins + install deps)
+        run: chmod +x cleanup.sh && ./cleanup.sh
+
+      # @voiden/mcp imports @voiden/runner's compiled dist/lib.js at build
+      # time (TypeScript type resolution via "exports") — build it first the
+      # same way release-runner.yml itself does.
+      - name: Build @voiden/runner
+        working-directory: packages/voiden-runner
+        run: npm run build
+
+      - name: Build @voiden/mcp
+        working-directory: packages/voiden-mcp
+        run: npm run build
+
+      # ── Publish to npm (Trusted Publishing / OIDC — no token needed) ─────────────
+      - name: Upgrade npm (OIDC support needs npm >=11.5.1)
+        run: npm install -g npm@11
+
+      # Fail fast rather than publish a bare "*" dependency: @voiden/runner
+      # has its own dedicated release workflow (release-runner.yml), so this
+      # workflow doesn't publish it — just refuses to proceed if the version
+      # in packages/voiden-runner/package.json isn't on npm yet.
+      - name: Verify @voiden/runner is published
+        id: runner
+        run: |
+          RUNNER_VERSION=$(node -p "require('./packages/voiden-runner/package.json').version")
+          echo "version=$RUNNER_VERSION" >> "$GITHUB_OUTPUT"
+          if ! npm view "@voiden/runner@$RUNNER_VERSION" version >/dev/null 2>&1; then
+            echo "::error::@voiden/runner@$RUNNER_VERSION is not published to npm yet. Run 'Release voiden-runner' (release-runner.yml) first."
+            exit 1
+          fi
+
+      # Pin the dependency to the version we just verified is on npm, instead
+      # of relying on npm's workspace:* → "*" rewrite at publish time.
+      - name: Pin @voiden/runner dependency to published version
+        working-directory: packages/voiden-mcp
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.dependencies['@voiden/runner'] = '${{ steps.runner.outputs.version }}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish to npm
+        working-directory: packages/voiden-mcp
+        run: npm publish --access public --provenance
+
+      # ── Attach tarball to GitHub Release ─────────────────────────────────────
+      - name: Pack tarball
+        working-directory: packages/voiden-mcp
+        run: npm pack
+
+      - name: Get tarball name
+        id: tarball
+        working-directory: packages/voiden-mcp
+        run: echo "name=$(ls *.tgz)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: voiden-mcp ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          body: |
+            ### Install
+
+            The package that actually runs the MCP server — no subcommand, invoking it starts the
+            server. Registered automatically by `voiden agent` (the Voiden app's CLI) or
+            `voiden-runner mcp install`, or add directly to Claude Code's `.mcp.json` / Codex's
+            `~/.codex/config.toml`:
+
+            ```json
+            { "mcpServers": { "voiden-mcp": { "command": "npx", "args": ["-y", "@voiden/mcp", "/path/to/project"] } } }
+            ```
+
+            To run it standalone (e.g. in CI, a Dockerfile, a systemd unit):
+            ```bash
+            npx @voiden/mcp ./path/to/project --http --port 3000
+            ```
+
+            Or install this release's tarball directly:
+            ```bash
+            npm install -g https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag }}/${{ steps.tarball.outputs.name }}
+            ```
+          files: packages/voiden-mcp/${{ steps.tarball.outputs.name }}


### PR DESCRIPTION
## Why

GitHub only allows `workflow_dispatch` to be triggered — via the API, `gh workflow run`, or the Actions UI "Run workflow" button — for workflow files that exist on the **default branch**, regardless of which `--ref` the dispatch itself targets. `release-mcp.yml` (the current `@voiden/mcp` release workflow, replacing the retired `release-mcp-server.yml`) exists on `beta` but was never brought to `main`, so it currently can't be dispatched at all — confirmed via `gh workflow run` returning a 404.

## What

Adds just this one workflow file, unchanged from `beta`, so `main`'s registry picks it up. Nothing else from `beta` is included in this PR. Once merged, `gh workflow run release-mcp.yml --ref beta` (or any other ref) becomes possible — `--ref` still controls which branch's code actually gets built and published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)