### PR TITLE
fix: prevent search selection auto-scroll

### DIFF
--- a/apps/ui/src/core/editors/code/CodeEditor.tsx
+++ b/apps/ui/src/core/editors/code/CodeEditor.tsx
@@ -30,6 +30,7 @@ import { yaml } from "@codemirror/lang-yaml";
 import { langs } from "@uiw/codemirror-extensions-langs";
 import { useCodeEditorStore } from "./CodeEditorStore";
 import { lintYaml } from "@/core/editors/code/lib/extensions/lintYaml";
+import { createHiddenSearchPanel } from "./lib/createHiddenSearchPanel";
 
 interface CodeEditorProps {
   tabId: string;
@@ -1072,7 +1073,7 @@ export const CodeEditor = memo(({ tabId, content, source, panelId, isActive = tr
       // "scrolls right, then snaps to the new line" glitch while typing.
       EditorView.lineWrapping,
       lintCompartment.of(initialLint),
-      search({ top: true, createPanel: () => ({ dom: document.createElement("div") }) }),
+      search({ top: true, createPanel: createHiddenSearchPanel }),
       Prec.highest(keymap.of([
         {
           key: "Mod-f", preventDefault: true, run: () => {

--- a/apps/ui/src/core/editors/code/__test__/hiddenSearchPanel.test.ts
+++ b/apps/ui/src/core/editors/code/__test__/hiddenSearchPanel.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openSearchPanel, search } from "@codemirror/search";
+import { EditorView } from "@codemirror/view";
+import { createHiddenSearchPanel } from "../lib/createHiddenSearchPanel";
+
+const mountedViews: EditorView[] = [];
+
+afterEach(() => {
+  mountedViews.splice(0).forEach((view) => view.destroy());
+  document.body.replaceChildren();
+});
+
+describe("createHiddenSearchPanel", () => {
+  it("keeps CodeMirror's bridge panel hidden and out of the bottom panel group", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      doc: "alpha\nbeta",
+      extensions: [search({ top: true, createPanel: createHiddenSearchPanel })],
+      parent,
+    });
+    mountedViews.push(view);
+
+    openSearchPanel(view);
+
+    vi.spyOn(view.scrollDOM, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 800,
+      bottom: 720,
+      left: 0,
+      width: 800,
+      height: 720,
+      toJSON: () => ({}),
+    });
+
+    const panel = view.dom.querySelector<HTMLElement>(".cm-panel");
+    const margins = view.state
+      .facet(EditorView.scrollMargins)
+      .map((source) => source(view));
+    expect(panel?.hidden).toBe(true);
+    expect(view.dom.querySelector(".cm-panels-top")).not.toBeNull();
+    expect(view.dom.querySelector(".cm-panels-bottom")).toBeNull();
+    expect(Math.max(0, ...margins.map((margin) => margin?.bottom ?? 0))).toBe(0);
+  });
+});

--- a/apps/ui/src/core/editors/code/lib/createHiddenSearchPanel.ts
+++ b/apps/ui/src/core/editors/code/lib/createHiddenSearchPanel.ts
@@ -1,0 +1,14 @@
+import type { Panel } from "@codemirror/view";
+
+/**
+ * CodeMirror's search state still needs a panel while Voiden renders its own
+ * persistent search controls outside the editor. Keep that bridge panel out of
+ * layout and explicitly place it at the top. An unspecified position defaults
+ * to the bottom and is interpreted as a viewport-sized bottom scroll margin
+ * when the surrounding panel group is hidden.
+ */
+export function createHiddenSearchPanel(): Panel {
+  const dom = document.createElement("div");
+  dom.hidden = true;
+  return { dom, top: true };
+}


### PR DESCRIPTION
Fixes #558

## Summary
- keep the hidden CodeMirror search bridge panel out of layout
- explicitly place the bridge at the top so it cannot become a viewport-sized bottom scroll margin
- add a regression test for panel placement and the resulting bottom margin

## Root cause
Voiden renders its persistent Find controls outside CodeMirror, but still opens an empty internal panel to initialize CodeMirror search state. Custom CodeMirror panels default to the bottom unless the returned panel specifies `top: true`. Because the internal panel group is hidden, CodeMirror measured it as a full-height bottom scroll margin. Its drag-selection logic therefore treated ordinary pointer positions as below the viewport and continuously scrolled downward.

## Verification
- `vitest --config vitest.config.ts run src/core/editors/code/__test__/hiddenSearchPanel.test.ts` (passes)
- exact component reproduction before the fix reported a 720px bottom scroll margin and advanced `scrollTop` during a held, mid-viewport drag; the regression test now asserts a zero bottom margin

## Existing baseline issues
The full UI run completed 188 tests successfully but still has one unrelated pipeline assertion failure and one existing plugin mock suite error.